### PR TITLE
Apply pydantic models to external API responses

### DIFF
--- a/modules/api_models.py
+++ b/modules/api_models.py
@@ -1,0 +1,89 @@
+from pydantic import BaseModel, ConfigDict
+
+# --- 서울 한강 수온 ---
+
+
+class HangangWaterRow(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    WATT: str
+
+
+class HangangWaterData(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    row: list[HangangWaterRow]
+
+
+class HangangWaterResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    WPOSInformationTime: HangangWaterData
+
+
+# --- 카카오 웹 검색 ---
+
+
+class KakaoSearchDocument(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    title: str = ""
+    contents: str = ""
+    url: str = ""
+
+
+class KakaoSearchResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    documents: list[KakaoSearchDocument] = []
+
+
+# --- 카카오 좌표→주소 ---
+
+
+class KakaoAddress(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    address_name: str = ""
+
+
+class KakaoAddressDocument(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    address: KakaoAddress
+
+
+class KakaoAddressResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    documents: list[KakaoAddressDocument]
+
+
+# --- OpenWeatherMap ---
+
+
+class WeatherDescription(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    description: str = ""
+
+
+class WeatherMain(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    temp: float
+    feels_like: float
+    humidity: float
+
+
+class WeatherResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    weather: list[WeatherDescription]
+    main: WeatherMain
+
+
+# --- Laftel 편성표 ---
+
+
+class LaftelAnime(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    id: int = 0
+    name: str = ""
+    genres: list[str] = []
+    content_rating: str = ""
+    distributed_air_time: str = ""
+    is_ending: bool = False
+    is_laftel_only: bool = False
+    is_exclusive: bool = False
+    is_dubbed: bool = False

--- a/modules/features_hub.py
+++ b/modules/features_hub.py
@@ -110,9 +110,9 @@ class BotFeaturesHub:
             result = self.web_manager.daum_search(message, None)
             result_contents = ""
 
-            for doc in result["documents"][:5]:
-                link = f"[{strings.search_more_link_msg}]({doc['url']})"
-                result_contents += strip_html_tags(f"*{doc['title']}*\n{doc['contents']}\n{link}\n\n")
+            for doc in result.documents[:5]:
+                link = f"[{strings.search_more_link_msg}]({doc.url})"
+                result_contents += strip_html_tags(f"*{doc.title}*\n{doc.contents}\n{link}\n\n")
             text = strings.search_result_header_msg + strip_html_tags(result_contents)
             self.bot.reply_to(message, text, parse_mode="Markdown")
         except Exception:

--- a/modules/laftel.py
+++ b/modules/laftel.py
@@ -2,8 +2,10 @@ import datetime
 
 import requests
 import telebot
+from pydantic import TypeAdapter
 
 from modules import log
+from modules.api_models import LaftelAnime
 from resources import strings
 
 logger = log.Logger()
@@ -145,10 +147,10 @@ class LaftelService:
                 headers=LAFTEL_HEADERS,
                 timeout=10,
             )
-            data = response.json()
+            anime_list = TypeAdapter(list[LaftelAnime]).validate_json(response.content)
             grouped = {}
-            for item in data:
-                day = item.get("distributed_air_time", "")
+            for item in anime_list:
+                day = item.distributed_air_time
                 if day not in grouped:
                     grouped[day] = []
                 grouped[day].append(item)
@@ -169,25 +171,24 @@ class LaftelService:
         header = strings.laftel_schedule_header_msg.format(day_name)
         entries = []
         for item in items:
-            genres = _escape_markdown(", ".join(item.get("genres", [])))
-            raw_rating = item.get("content_rating", "")
-            rating = RATING_LABELS.get(raw_rating, raw_rating)
+            genres = _escape_markdown(", ".join(item.genres))
+            rating = RATING_LABELS.get(item.content_rating, item.content_rating)
 
             tags = []
-            if item.get("is_laftel_only") or item.get("is_exclusive"):
+            if item.is_laftel_only or item.is_exclusive:
                 tags.append("[독점]")
-            if item.get("is_dubbed"):
+            if item.is_dubbed:
                 tags.append("[더빙]")
-            if item.get("is_ending"):
+            if item.is_ending:
                 tags.append("[완결]")
             tags_str = _escape_markdown(" ".join(tags))
 
             entry = strings.laftel_schedule_entry_msg.format(
-                name=_escape_markdown(item.get("name", "")),
+                name=_escape_markdown(item.name),
                 genres=genres,
                 rating=rating,
                 tags=tags_str,
-                item_id=item.get("id", ""),
+                item_id=item.id,
             )
             entries.append(entry)
 

--- a/modules/web_based.py
+++ b/modules/web_based.py
@@ -1,11 +1,16 @@
 import datetime
-import json
 import urllib.parse
 
 import requests
 
 from config import config
 from modules import log
+from modules.api_models import (
+    HangangWaterResponse,
+    KakaoAddressResponse,
+    KakaoSearchResponse,
+    WeatherResponse,
+)
 from modules.utils import extract_command_args, strip_html_tags
 from resources import strings
 
@@ -46,8 +51,8 @@ class WebManager:
         else:
             try:
                 search_request = requests.get(config.SEOUL_HANGANG_WATER_URL, timeout=10)
-                result = json.loads(search_request.text)
-                self.suon_v2 = result["WPOSInformationTime"]["row"][0]["WATT"]
+                parsed = HangangWaterResponse.model_validate_json(search_request.text)
+                self.suon_v2 = parsed.WPOSInformationTime.row[0].WATT
             except Exception:
                 logger.log_error("Retreiving water information of Hangang failed. Please check API Status.")
                 self.suon_v2 = None
@@ -63,33 +68,33 @@ class WebManager:
 
         try:
             search_request = requests.get(search_url, headers=search_headers, timeout=10)
-            result = json.loads(search_request.text)
+            parsed = KakaoSearchResponse.model_validate_json(search_request.text)
         except Exception:
-            return {"documents": []}
+            return KakaoSearchResponse()
 
-        for i in result["documents"]:
-            urlinfo = urllib.parse.urlsplit(i["url"])
-            i["url"] = f"{urlinfo.scheme}://{urlinfo.netloc}{urllib.parse.quote(urlinfo.path, safe='/:@!$&*+,;=%')}"
+        for doc in parsed.documents:
+            urlinfo = urllib.parse.urlsplit(doc.url)
+            doc.url = f"{urlinfo.scheme}://{urlinfo.netloc}{urllib.parse.quote(urlinfo.path, safe='/:@!$&*+,;=%')}"
 
-        return result
+        return parsed
 
     # Search from Namu.wiki
     def namuwiki_search(self, message):
         keyword = extract_command_args(message.text)
         url = NAMUWIKI_BASE_URL + urllib.parse.quote(keyword)
 
-        documents = self.daum_search(message, "namu.wiki")["documents"]
+        documents = self.daum_search(message, "namu.wiki").documents
         if not documents:
             return strings.search_no_result_msg
 
         result = documents[0]
-        result_contents = result["contents"]
-        result_url = result["url"]
+        result_contents = result.contents
+        result_url = result.url
 
         text = strip_html_tags(result_contents)
 
         if result_url != url:
-            result_title = strip_html_tags(result["title"])
+            result_title = strip_html_tags(result.title)
             return (
                 strings.search_mismatch_msg.format(keyword=keyword)
                 + "["
@@ -112,18 +117,19 @@ class WebManager:
         weather_args = {"lang": "kr", "appid": config.WEATHER_TOKEN, "lat": latitude, "lon": longitude}
         weather_url = WEATHER_BASE_URL + urllib.parse.urlencode(weather_args)
         weather_request = requests.get(weather_url, timeout=10)
-        weather_json = json.loads(weather_request.text)
+        weather_data = WeatherResponse.model_validate_json(weather_request.text)
 
-        weather = weather_json["weather"][0]["description"]
-        temp = str(round(weather_json["main"]["temp"] - 273.15)) + "°C"
-        feels_temp = str(round(weather_json["main"]["feels_like"] - 273.15)) + "°C"
-        humidity = str(round(weather_json["main"]["humidity"])) + "%"
+        weather = weather_data.weather[0].description
+        temp = str(round(weather_data.main.temp - 273.15)) + "°C"
+        feels_temp = str(round(weather_data.main.feels_like - 273.15)) + "°C"
+        humidity = str(round(weather_data.main.humidity)) + "%"
 
         weather_result = strings.geolocation_weather_msg.format(
             weather=weather, temp=temp, feels_temp=feels_temp, humidity=humidity
         )
 
-        map_location = json.loads(map_request.text)["documents"][0]["address"]["address_name"]
+        map_parsed = KakaoAddressResponse.model_validate_json(map_request.text)
+        map_location = map_parsed.documents[0].address.address_name
         geo_location = strings.geolocation_coords_msg.format(latitude=latitude, longitude=longitude)
 
         return geo_location + "\n" + map_location + "\n\n" + weather_result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "requests>=2.28,<3",
     "python-dotenv>=1.0,<2",
     "google-genai>=1.0,<2",
+    "pydantic>=2.9,<3",
     "peewee>=3.17,<5",
     "telegramify-markdown>=1.0,<2",
 ]

--- a/tests/test_laftel.py
+++ b/tests/test_laftel.py
@@ -1,6 +1,7 @@
 import datetime
 from unittest.mock import MagicMock, patch
 
+from modules.api_models import LaftelAnime
 from modules.laftel import CACHE_INTERVAL, DAY_CODES, DAYS_OF_WEEK, LaftelService
 from resources import strings
 
@@ -43,8 +44,10 @@ def _make_service(**overrides):
 class TestFetchDailySchedule:
     @patch("modules.laftel.requests.get")
     def test_success_groups_by_day(self, mock_get):
+        import json
+
         response = MagicMock()
-        response.json.return_value = SAMPLE_SCHEDULE
+        response.content = json.dumps(SAMPLE_SCHEDULE).encode()
         mock_get.return_value = response
 
         svc = _make_service()
@@ -88,7 +91,7 @@ class TestFetchDailySchedule:
     @patch("modules.laftel.requests.get")
     def test_cache_expired_refetches(self, mock_get):
         response = MagicMock()
-        response.json.return_value = []
+        response.content = b"[]"
         mock_get.return_value = response
 
         svc = _make_service(
@@ -104,26 +107,12 @@ class TestGetScheduleByDay:
     def test_normal_output(self):
         cache = {
             "월요일": [
-                {
-                    "id": 1,
-                    "name": "애니A",
-                    "genres": ["액션", "판타지"],
-                    "content_rating": "15세 이용가",
-                    "is_laftel_only": True,
-                    "is_ending": False,
-                    "is_dubbed": False,
-                    "is_exclusive": False,
-                },
-                {
-                    "id": 2,
-                    "name": "애니B",
-                    "genres": ["로맨스"],
-                    "content_rating": "성인 이용가",
-                    "is_laftel_only": False,
-                    "is_ending": True,
-                    "is_dubbed": True,
-                    "is_exclusive": False,
-                },
+                LaftelAnime(
+                    id=1, name="애니A", genres=["액션", "판타지"], content_rating="15세 이용가", is_laftel_only=True
+                ),
+                LaftelAnime(
+                    id=2, name="애니B", genres=["로맨스"], content_rating="성인 이용가", is_ending=True, is_dubbed=True
+                ),
             ]
         }
         svc = _make_service(_schedule_cache=cache, _last_fetch_time=datetime.datetime.now())
@@ -149,12 +138,12 @@ class TestGetScheduleByDay:
 
     def test_truncation_on_long_list(self):
         items = [
-            {
-                "id": i,
-                "name": f"매우 긴 제목의 애니메이션 {i}",
-                "genres": ["장르A", "장르B", "장르C"],
-                "content_rating": "15세 이용가",
-            }
+            LaftelAnime(
+                id=i,
+                name=f"매우 긴 제목의 애니메이션 {i}",
+                genres=["장르A", "장르B", "장르C"],
+                content_rating="15세 이용가",
+            )
             for i in range(200)
         ]
         svc = _make_service(_schedule_cache={"월요일": items}, _last_fetch_time=datetime.datetime.now())
@@ -246,20 +235,7 @@ class TestHandleLaftelCallback:
         assert svc.bot.edit_message_text.call_args[1]["reply_markup"] is not None
 
     def test_schedule_day_shows_formatted_text(self):
-        cache = {
-            "월요일": [
-                {
-                    "id": 1,
-                    "name": "테스트",
-                    "genres": ["액션"],
-                    "content_rating": "15세 이용가",
-                    "is_laftel_only": False,
-                    "is_ending": False,
-                    "is_dubbed": False,
-                    "is_exclusive": False,
-                }
-            ]
-        }
+        cache = {"월요일": [LaftelAnime(id=1, name="테스트", genres=["액션"], content_rating="15세 이용가")]}
         svc = _make_service(_schedule_cache=cache, _last_fetch_time=datetime.datetime.now())
 
         call = MagicMock()

--- a/tests/test_web_based.py
+++ b/tests/test_web_based.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from modules.api_models import KakaoSearchDocument, KakaoSearchResponse
 from modules.web_based import WebManager
 from resources import strings
 from tests.conftest import make_message
@@ -105,7 +106,7 @@ class TestDaumSearch:
             wm = WebManager()
             msg = make_message("/search test")
             result = wm.daum_search(msg, None)
-            assert len(result["documents"]) == 1
+            assert len(result.documents) == 1
 
     @patch("modules.web_based.config.KAKAO_TOKEN", "test_token")
     @patch("modules.web_based.requests.get")
@@ -118,7 +119,7 @@ class TestDaumSearch:
             wm = WebManager()
             msg = make_message("/search nothing")
             result = wm.daum_search(msg, None)
-            assert result["documents"] == []
+            assert result.documents == []
 
     @patch("modules.web_based.config.KAKAO_TOKEN", "test_token")
     @patch("modules.web_based.requests.get")
@@ -129,7 +130,7 @@ class TestDaumSearch:
             wm = WebManager()
             msg = make_message("/search fail")
             result = wm.daum_search(msg, None)
-            assert result == {"documents": []}
+            assert result.documents == []
 
 
 class TestDaumSearchMultiWord:
@@ -154,15 +155,9 @@ class TestDaumSearchMultiWord:
 class TestNamuwikiSearch:
     @patch.object(WebManager, "daum_search")
     def test_normal_result(self, mock_daum):
-        mock_daum.return_value = {
-            "documents": [
-                {
-                    "title": "test",
-                    "contents": "<b>content</b>",
-                    "url": "https://namu.wiki/w/test",
-                }
-            ]
-        }
+        mock_daum.return_value = KakaoSearchResponse(
+            documents=[KakaoSearchDocument(title="test", contents="<b>content</b>", url="https://namu.wiki/w/test")]
+        )
 
         with patch.object(WebManager, "__init__", lambda self: None):
             wm = WebManager()
@@ -172,7 +167,7 @@ class TestNamuwikiSearch:
 
     @patch.object(WebManager, "daum_search")
     def test_empty_documents(self, mock_daum):
-        mock_daum.return_value = {"documents": []}
+        mock_daum.return_value = KakaoSearchResponse()
 
         with patch.object(WebManager, "__init__", lambda self: None):
             wm = WebManager()
@@ -185,15 +180,15 @@ class TestNamuwikiSearchMultiWord:
     @patch.object(WebManager, "daum_search")
     def test_multi_word_keyword(self, mock_daum):
         encoded = urllib.parse.quote("hello world")
-        mock_daum.return_value = {
-            "documents": [
-                {
-                    "title": "hello world",
-                    "contents": "<b>some content</b>",
-                    "url": "https://namu.wiki/w/" + encoded,
-                }
+        mock_daum.return_value = KakaoSearchResponse(
+            documents=[
+                KakaoSearchDocument(
+                    title="hello world",
+                    contents="<b>some content</b>",
+                    url="https://namu.wiki/w/" + encoded,
+                )
             ]
-        }
+        )
 
         with patch.object(WebManager, "__init__", lambda self: None):
             wm = WebManager()
@@ -206,15 +201,15 @@ class TestNamuwikiSearchMultiWord:
 class TestNamuwikiSearchUrlMismatch:
     @patch.object(WebManager, "daum_search")
     def test_url_mismatch_shows_actual_result(self, mock_daum):
-        mock_daum.return_value = {
-            "documents": [
-                {
-                    "title": "<b>Different</b> Page",
-                    "contents": "<b>content</b> here",
-                    "url": "https://namu.wiki/w/different_page",
-                }
+        mock_daum.return_value = KakaoSearchResponse(
+            documents=[
+                KakaoSearchDocument(
+                    title="<b>Different</b> Page",
+                    contents="<b>content</b> here",
+                    url="https://namu.wiki/w/different_page",
+                )
             ]
-        }
+        )
 
         with patch.object(WebManager, "__init__", lambda self: None):
             wm = WebManager()


### PR DESCRIPTION
## Summary
- 5개 외부 REST API 응답에 pydantic 모델을 적용하여 타입 안전성 확보
- json.loads + dict 키 접근을 model_validate_json + 속성 접근으로 전환
- API 응답 구조 변경 시 ValidationError로 즉시 감지

## Changes
### New
- `modules/api_models.py`: 5개 API 응답 pydantic 모델 11개 클래스 정의 (서울 수온, 카카오 검색/주소, OpenWeatherMap, Laftel)
- `pyproject.toml`: pydantic>=2.9,<3 직접 의존성 추가

### Refactoring
- `modules/web_based.py`: json.loads → model_validate_json, dict 키 접근 → 속성 접근, import json 제거
- `modules/laftel.py`: response.json() → TypeAdapter.validate_json(), .get() → 속성 접근
- `modules/features_hub.py`: 검색 결과 dict 접근 → 모델 속성 접근
- `tests/test_web_based.py`: 나무위키 테스트 mock을 KakaoSearchResponse 모델로 전환
- `tests/test_laftel.py`: 캐시 테스트 데이터를 LaftelAnime 모델로 전환

## Test plan
- [x] ruff check / ruff format 통과
- [x] pytest 319 passed