### PR TITLE
Add ranking and keyword search to Laftel portal

### DIFF
--- a/.claude/rules/pull-request.md
+++ b/.claude/rules/pull-request.md
@@ -43,3 +43,4 @@
 
 - 기술 용어(rate limit, thread safety, inline keyboard 등)는 무리하게 한국어로 번역하지 않음
 - PR 생성 전 반드시 초안을 사용자에게 보여주고 승인받을 것
+- **PR merge 후 브랜치 삭제 금지** — `development`, `master` 등 주요 브랜치는 물론 작업 브랜치도 merge 후 삭제하지 않음

--- a/bin/handlers.py
+++ b/bin/handlers.py
@@ -184,6 +184,13 @@ def register_handlers(bot, hub, logger):
     def handle_prompt_reply(message):
         hub.handle_prompt_reply(message)
 
+    # ForceReply handler for Laftel search
+    @bot.message_handler(
+        func=lambda m: m.reply_to_message and m.reply_to_message.text == strings.laftel_search_input_msg
+    )
+    def handle_laftel_search_reply(message):
+        hub.laftel.handle_search_reply(message)
+
     # Ordinary message
     @bot.message_handler(content_types=["text"])
     @safe_handler

--- a/modules/api_models.py
+++ b/modules/api_models.py
@@ -82,7 +82,7 @@ class LaftelAnime(BaseModel):
     name: str = ""
     genres: list[str] = []
     content_rating: str = ""
-    distributed_air_time: str = ""
+    distributed_air_time: str | None = ""
     is_ending: bool = False
     is_laftel_only: bool = False
     is_exclusive: bool = False

--- a/modules/api_models.py
+++ b/modules/api_models.py
@@ -72,7 +72,7 @@ class WeatherResponse(BaseModel):
     main: WeatherMain
 
 
-# --- Laftel 편성표 ---
+# --- Laftel ---
 
 
 class LaftelAnime(BaseModel):
@@ -87,3 +87,10 @@ class LaftelAnime(BaseModel):
     is_laftel_only: bool = False
     is_exclusive: bool = False
     is_dubbed: bool = False
+
+
+class LaftelSearchResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    count: int = 0
+    results: list[LaftelAnime] = []

--- a/modules/api_models.py
+++ b/modules/api_models.py
@@ -79,14 +79,14 @@ class LaftelAnime(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     id: int = 0
-    name: str = ""
-    genres: list[str] = []
-    content_rating: str = ""
+    name: str | None = ""
+    genres: list[str] | None = []
+    content_rating: str | None = ""
     distributed_air_time: str | None = ""
-    is_ending: bool = False
-    is_laftel_only: bool = False
-    is_exclusive: bool = False
-    is_dubbed: bool = False
+    is_ending: bool | None = False
+    is_laftel_only: bool | None = False
+    is_exclusive: bool | None = False
+    is_dubbed: bool | None = False
 
 
 class LaftelSearchResponse(BaseModel):

--- a/modules/laftel.py
+++ b/modules/laftel.py
@@ -17,7 +17,13 @@ MAX_MESSAGE_LENGTH = 4096
 
 SETTINGS_MODULE_PATH = "modules.laftel"
 
-CALLBACK_PREFIXES = frozenset({"laftel_menu", "laftel_schedule"})
+CALLBACK_PREFIXES = frozenset({"laftel_menu", "laftel_schedule", "laftel_ranking"})
+
+RANKING_TYPES = {
+    "week": "주간",
+    "quarter": "분기",
+    "history": "역대",
+}
 
 DAYS_OF_WEEK = ("월요일", "화요일", "수요일", "목요일", "금요일", "토요일", "일요일")
 DAY_CODES = {
@@ -52,6 +58,8 @@ class LaftelService:
         # 캐시: GIL이 참조 할당의 원자성을 보장하므로 별도 락 불필요 (WebManager 동일 패턴)
         self._schedule_cache = None
         self._last_fetch_time = None
+        self._ranking_cache = {}
+        self._ranking_fetch_time = {}
 
     # --- 콜백 라우팅 ---
 
@@ -65,6 +73,8 @@ class LaftelService:
             self._handle_menu(call, value)
         elif action == "laftel_schedule":
             self._handle_schedule(call, value)
+        elif action == "laftel_ranking":
+            self._handle_ranking(call, value)
 
     def _handle_menu(self, call, value):
         if value == "portal":
@@ -85,6 +95,15 @@ class LaftelService:
                 parse_mode="Markdown",
                 reply_markup=self._build_day_selection_keyboard(),
             )
+        elif value == "ranking":
+            result = self._get_ranking("week")
+            self.bot.edit_message_text(
+                result,
+                call.message.chat.id,
+                call.message.message_id,
+                parse_mode="Markdown",
+                reply_markup=self._build_ranking_type_keyboard(),
+            )
 
     def _handle_schedule(self, call, value):
         day = value
@@ -100,6 +119,18 @@ class LaftelService:
             call.message.message_id,
             parse_mode="Markdown",
             reply_markup=self._build_day_selection_keyboard(),
+        )
+
+    def _handle_ranking(self, call, value):
+        if value not in RANKING_TYPES:
+            return
+        result = self._get_ranking(value)
+        self.bot.edit_message_text(
+            result,
+            call.message.chat.id,
+            call.message.message_id,
+            parse_mode="Markdown",
+            reply_markup=self._build_ranking_type_keyboard(),
         )
 
     # --- 포털 ---
@@ -118,6 +149,7 @@ class LaftelService:
         keyboard = telebot.types.InlineKeyboardMarkup()
         keyboard.row(
             telebot.types.InlineKeyboardButton(strings.laftel_schedule_btn, callback_data="laftel_menu:schedule"),
+            telebot.types.InlineKeyboardButton(strings.laftel_ranking_btn, callback_data="laftel_menu:ranking"),
         )
         return keyboard
 
@@ -205,3 +237,85 @@ class LaftelService:
             text = truncated + strings.laftel_schedule_truncated_msg + "\n" + footer
 
         return text
+
+    # --- 랭킹 데이터 ---
+
+    def _fetch_ranking(self, ranking_type):
+        now = datetime.datetime.now()
+        fetch_time = self._ranking_fetch_time.get(ranking_type)
+        if ranking_type in self._ranking_cache and fetch_time:
+            elapsed = (now - fetch_time).total_seconds()
+            if elapsed < CACHE_INTERVAL:
+                return
+
+        try:
+            response = requests.get(
+                LAFTEL_BASE_URL + f"home/v1/recommend/ranking?type={ranking_type}",
+                headers=LAFTEL_HEADERS,
+                timeout=10,
+            )
+            anime_list = TypeAdapter(list[LaftelAnime]).validate_json(response.content)
+            self._ranking_cache[ranking_type] = anime_list
+            self._ranking_fetch_time[ranking_type] = now
+        except Exception:
+            logger.log_error(f"Failed to fetch Laftel ranking (type={ranking_type}).")
+            if ranking_type not in self._ranking_cache:
+                self._ranking_cache[ranking_type] = []
+
+    def _get_ranking(self, ranking_type):
+        self._fetch_ranking(ranking_type)
+
+        items = self._ranking_cache.get(ranking_type, [])
+        type_label = RANKING_TYPES.get(ranking_type, ranking_type)
+        if not items:
+            return strings.laftel_ranking_empty_msg
+
+        header = strings.laftel_ranking_header_msg.format(type_label)
+        entries = []
+        for rank, item in enumerate(items, 1):
+            genres = _escape_markdown(", ".join(item.genres))
+            rating = RATING_LABELS.get(item.content_rating, item.content_rating)
+
+            tags = []
+            if item.is_laftel_only or item.is_exclusive:
+                tags.append("[독점]")
+            if item.is_dubbed:
+                tags.append("[더빙]")
+            if item.is_ending:
+                tags.append("[완결]")
+            tags_str = _escape_markdown(" ".join(tags))
+
+            entry = strings.laftel_ranking_entry_msg.format(
+                rank=rank,
+                name=_escape_markdown(item.name),
+                genres=genres,
+                rating=rating,
+                tags=tags_str,
+                item_id=item.id,
+            )
+            entries.append(entry)
+
+        footer = strings.laftel_ranking_footer_msg.format(len(items))
+        text = header + "".join(entries) + footer
+
+        if len(text) > MAX_MESSAGE_LENGTH:
+            truncated = header
+            for entry in entries:
+                remaining = len(footer) + len(strings.laftel_schedule_truncated_msg)
+                if len(truncated) + len(entry) + remaining > MAX_MESSAGE_LENGTH:
+                    break
+                truncated += entry
+            text = truncated + strings.laftel_schedule_truncated_msg + "\n" + footer
+
+        return text
+
+    @staticmethod
+    def _build_ranking_type_keyboard():
+        keyboard = telebot.types.InlineKeyboardMarkup()
+        keyboard.row(
+            *[
+                telebot.types.InlineKeyboardButton(label, callback_data=f"laftel_ranking:{code}")
+                for code, label in RANKING_TYPES.items()
+            ]
+        )
+        return keyboard

--- a/modules/laftel.py
+++ b/modules/laftel.py
@@ -197,7 +197,7 @@ class LaftelService:
             anime_list = TypeAdapter(list[LaftelAnime]).validate_json(response.content)
             grouped = {}
             for item in anime_list:
-                day = item.distributed_air_time
+                day = item.distributed_air_time or ""
                 if day not in grouped:
                     grouped[day] = []
                 grouped[day].append(item)

--- a/modules/laftel.py
+++ b/modules/laftel.py
@@ -1,11 +1,13 @@
 import datetime
+import time
+import urllib.parse
 
 import requests
 import telebot
 from pydantic import TypeAdapter
 
 from modules import log
-from modules.api_models import LaftelAnime
+from modules.api_models import LaftelAnime, LaftelSearchResponse
 from resources import strings
 
 logger = log.Logger()
@@ -14,6 +16,7 @@ LAFTEL_BASE_URL = "https://laftel.net/api/"
 LAFTEL_HEADERS = {"laftel": "TeJava"}
 CACHE_INTERVAL = 3600
 MAX_MESSAGE_LENGTH = 4096
+SEARCH_INPUT_TIMEOUT = 300
 
 SETTINGS_MODULE_PATH = "modules.laftel"
 
@@ -60,6 +63,7 @@ class LaftelService:
         self._last_fetch_time = None
         self._ranking_cache = {}
         self._ranking_fetch_time = {}
+        self._pending_search = None
 
     # --- 콜백 라우팅 ---
 
@@ -103,6 +107,14 @@ class LaftelService:
                 call.message.message_id,
                 parse_mode="Markdown",
                 reply_markup=self._build_ranking_type_keyboard(),
+            )
+        elif value == "search":
+            self._pending_search = (call.from_user.id, call.message.chat.id, time.time())
+            self.bot.edit_message_reply_markup(call.message.chat.id, call.message.message_id, reply_markup=None)
+            self.bot.send_message(
+                call.message.chat.id,
+                strings.laftel_search_input_msg,
+                reply_markup=telebot.types.ForceReply(selective=True),
             )
 
     def _handle_schedule(self, call, value):
@@ -150,6 +162,9 @@ class LaftelService:
         keyboard.row(
             telebot.types.InlineKeyboardButton(strings.laftel_schedule_btn, callback_data="laftel_menu:schedule"),
             telebot.types.InlineKeyboardButton(strings.laftel_ranking_btn, callback_data="laftel_menu:ranking"),
+        )
+        keyboard.row(
+            telebot.types.InlineKeyboardButton(strings.laftel_search_btn, callback_data="laftel_menu:search"),
         )
         return keyboard
 
@@ -319,3 +334,71 @@ class LaftelService:
             ]
         )
         return keyboard
+
+    # --- 검색 ---
+
+    def handle_search_reply(self, message):
+        if not self._pending_search:
+            return
+        user_id, chat_id, timestamp = self._pending_search
+        if message.from_user.id != user_id or message.chat.id != chat_id:
+            return
+        if time.time() - timestamp > SEARCH_INPUT_TIMEOUT:
+            self._pending_search = None
+            return
+        self._pending_search = None
+        keyword = message.text.strip()
+        result = self._search(keyword)
+        self.bot.reply_to(message, result, parse_mode="Markdown")
+
+    def _search(self, keyword):
+        try:
+            url = LAFTEL_BASE_URL + "search/v3/keyword/?" + urllib.parse.urlencode({"keyword": keyword})
+            response = requests.get(url, headers=LAFTEL_HEADERS, timeout=10)
+            parsed = LaftelSearchResponse.model_validate_json(response.content)
+        except Exception:
+            logger.log_error(f"Failed to search Laftel (keyword={keyword}).")
+            return strings.laftel_error_msg
+
+        items = parsed.results
+        if not items:
+            return strings.laftel_search_empty_msg.format(_escape_markdown(keyword))
+
+        header = strings.laftel_search_header_msg.format(_escape_markdown(keyword))
+        entries = []
+        for rank, item in enumerate(items, 1):
+            genres = _escape_markdown(", ".join(item.genres))
+            rating = RATING_LABELS.get(item.content_rating, item.content_rating)
+
+            tags = []
+            if item.is_laftel_only or item.is_exclusive:
+                tags.append("[독점]")
+            if item.is_dubbed:
+                tags.append("[더빙]")
+            if item.is_ending:
+                tags.append("[완결]")
+            tags_str = _escape_markdown(" ".join(tags))
+
+            entry = strings.laftel_ranking_entry_msg.format(
+                rank=rank,
+                name=_escape_markdown(item.name),
+                genres=genres,
+                rating=rating,
+                tags=tags_str,
+                item_id=item.id,
+            )
+            entries.append(entry)
+
+        footer = strings.laftel_search_footer_msg.format(len(items))
+        text = header + "".join(entries) + footer
+
+        if len(text) > MAX_MESSAGE_LENGTH:
+            truncated = header
+            for entry in entries:
+                remaining = len(footer) + len(strings.laftel_schedule_truncated_msg)
+                if len(truncated) + len(entry) + remaining > MAX_MESSAGE_LENGTH:
+                    break
+                truncated += entry
+            text = truncated + strings.laftel_schedule_truncated_msg + "\n" + footer
+
+        return text

--- a/modules/laftel.py
+++ b/modules/laftel.py
@@ -55,6 +55,38 @@ def _escape_markdown(text):
     return text
 
 
+def _format_entry(item, rank=None):
+    """LaftelAnime 항목을 포맷팅된 엔트리 문자열로 변환한다."""
+    genres = _escape_markdown(", ".join(item.genres or []))
+    rating = RATING_LABELS.get(item.content_rating or "", item.content_rating or "")
+
+    tags = []
+    if item.is_laftel_only or item.is_exclusive:
+        tags.append("[독점]")
+    if item.is_dubbed:
+        tags.append("[더빙]")
+    if item.is_ending:
+        tags.append("[완결]")
+    tags_str = _escape_markdown(" ".join(tags))
+
+    if rank is not None:
+        return strings.laftel_ranking_entry_msg.format(
+            rank=rank,
+            name=_escape_markdown(item.name or ""),
+            genres=genres,
+            rating=rating,
+            tags=tags_str,
+            item_id=item.id,
+        )
+    return strings.laftel_schedule_entry_msg.format(
+        name=_escape_markdown(item.name or ""),
+        genres=genres,
+        rating=rating,
+        tags=tags_str,
+        item_id=item.id,
+    )
+
+
 class LaftelService:
     def __init__(self, bot):
         self.bot = bot
@@ -216,28 +248,7 @@ class LaftelService:
             return strings.laftel_schedule_empty_msg.format(day_name)
 
         header = strings.laftel_schedule_header_msg.format(day_name)
-        entries = []
-        for item in items:
-            genres = _escape_markdown(", ".join(item.genres))
-            rating = RATING_LABELS.get(item.content_rating, item.content_rating)
-
-            tags = []
-            if item.is_laftel_only or item.is_exclusive:
-                tags.append("[독점]")
-            if item.is_dubbed:
-                tags.append("[더빙]")
-            if item.is_ending:
-                tags.append("[완결]")
-            tags_str = _escape_markdown(" ".join(tags))
-
-            entry = strings.laftel_schedule_entry_msg.format(
-                name=_escape_markdown(item.name),
-                genres=genres,
-                rating=rating,
-                tags=tags_str,
-                item_id=item.id,
-            )
-            entries.append(entry)
+        entries = [_format_entry(item) for item in items]
 
         footer = strings.laftel_schedule_footer_msg.format(len(items))
         text = header + "".join(entries) + footer
@@ -286,29 +297,7 @@ class LaftelService:
             return strings.laftel_ranking_empty_msg
 
         header = strings.laftel_ranking_header_msg.format(type_label)
-        entries = []
-        for rank, item in enumerate(items, 1):
-            genres = _escape_markdown(", ".join(item.genres))
-            rating = RATING_LABELS.get(item.content_rating, item.content_rating)
-
-            tags = []
-            if item.is_laftel_only or item.is_exclusive:
-                tags.append("[독점]")
-            if item.is_dubbed:
-                tags.append("[더빙]")
-            if item.is_ending:
-                tags.append("[완결]")
-            tags_str = _escape_markdown(" ".join(tags))
-
-            entry = strings.laftel_ranking_entry_msg.format(
-                rank=rank,
-                name=_escape_markdown(item.name),
-                genres=genres,
-                rating=rating,
-                tags=tags_str,
-                item_id=item.id,
-            )
-            entries.append(entry)
+        entries = [_format_entry(item, rank=rank) for rank, item in enumerate(items, 1)]
 
         footer = strings.laftel_ranking_footer_msg.format(len(items))
         text = header + "".join(entries) + footer
@@ -335,6 +324,15 @@ class LaftelService:
         )
         return keyboard
 
+    @staticmethod
+    def _build_search_result_keyboard():
+        keyboard = telebot.types.InlineKeyboardMarkup()
+        keyboard.row(
+            telebot.types.InlineKeyboardButton(strings.laftel_search_again_btn, callback_data="laftel_menu:search"),
+            telebot.types.InlineKeyboardButton(strings.laftel_portal_btn, callback_data="laftel_menu:portal"),
+        )
+        return keyboard
+
     # --- 검색 ---
 
     def handle_search_reply(self, message):
@@ -348,8 +346,11 @@ class LaftelService:
             return
         self._pending_search = None
         keyword = message.text.strip()
+        if not keyword:
+            self.bot.reply_to(message, strings.laftel_search_empty_input_msg)
+            return
         result = self._search(keyword)
-        self.bot.reply_to(message, result, parse_mode="Markdown")
+        self.bot.reply_to(message, result, parse_mode="Markdown", reply_markup=self._build_search_result_keyboard())
 
     def _search(self, keyword):
         try:
@@ -365,29 +366,7 @@ class LaftelService:
             return strings.laftel_search_empty_msg.format(_escape_markdown(keyword))
 
         header = strings.laftel_search_header_msg.format(_escape_markdown(keyword))
-        entries = []
-        for rank, item in enumerate(items, 1):
-            genres = _escape_markdown(", ".join(item.genres))
-            rating = RATING_LABELS.get(item.content_rating, item.content_rating)
-
-            tags = []
-            if item.is_laftel_only or item.is_exclusive:
-                tags.append("[독점]")
-            if item.is_dubbed:
-                tags.append("[더빙]")
-            if item.is_ending:
-                tags.append("[완결]")
-            tags_str = _escape_markdown(" ".join(tags))
-
-            entry = strings.laftel_ranking_entry_msg.format(
-                rank=rank,
-                name=_escape_markdown(item.name),
-                genres=genres,
-                rating=rating,
-                tags=tags_str,
-                item_id=item.id,
-            )
-            entries.append(entry)
+        entries = [_format_entry(item, rank=rank) for rank, item in enumerate(items, 1)]
 
         footer = strings.laftel_search_footer_msg.format(len(items))
         text = header + "".join(entries) + footer

--- a/resources/strings.py
+++ b/resources/strings.py
@@ -226,6 +226,9 @@ laftel_search_input_msg = "검색할 키워드를 입력해 주세요."
 laftel_search_header_msg = '*"{}" 검색 결과*\n\n'
 laftel_search_empty_msg = '"{}"에 대한 검색 결과가 없습니다.'
 laftel_search_footer_msg = "_(총 {}개)_"
+laftel_search_empty_input_msg = "검색할 키워드를 입력해 주세요."
+laftel_search_again_btn = "다시 검색"
+laftel_portal_btn = "포털로"
 laftel_help_msg = "/laftel 명령어로 라프텔 편성표, 랭킹, 검색 기능을 이용할 수 있습니다."
 
 # Resources

--- a/resources/strings.py
+++ b/resources/strings.py
@@ -221,7 +221,12 @@ laftel_ranking_entry_msg = (
 )
 laftel_ranking_empty_msg = "랭킹 정보를 가져올 수 없습니다."
 laftel_ranking_footer_msg = "_(총 {}개)_"
-laftel_help_msg = "/laftel 명령어로 라프텔 애니 편성표와 랭킹을 확인할 수 있습니다."
+laftel_search_btn = "검색"
+laftel_search_input_msg = "검색할 키워드를 입력해 주세요."
+laftel_search_header_msg = '*"{}" 검색 결과*\n\n'
+laftel_search_empty_msg = '"{}"에 대한 검색 결과가 없습니다.'
+laftel_search_footer_msg = "_(총 {}개)_"
+laftel_help_msg = "/laftel 명령어로 라프텔 편성표, 랭킹, 검색 기능을 이용할 수 있습니다."
 
 # Resources
 

--- a/resources/strings.py
+++ b/resources/strings.py
@@ -214,7 +214,14 @@ laftel_schedule_empty_msg = "{}에 편성된 신작이 없습니다."
 laftel_error_msg = "라프텔 정보를 가져오는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."
 laftel_schedule_footer_msg = "_(총 {}개)_"
 laftel_schedule_truncated_msg = "... 더 많은 작품은 laftel.net에서 확인해 주세요."
-laftel_help_msg = "/laftel 명령어로 라프텔 애니 편성표를 확인할 수 있습니다."
+laftel_ranking_btn = "랭킹"
+laftel_ranking_header_msg = "*{} 랭킹 Top 20*\n\n"
+laftel_ranking_entry_msg = (
+    "{rank}. *{name}*  {rating}\n   {genres} {tags}\n   [보기](https://laftel.net/item/{item_id})\n\n"
+)
+laftel_ranking_empty_msg = "랭킹 정보를 가져올 수 없습니다."
+laftel_ranking_footer_msg = "_(총 {}개)_"
+laftel_help_msg = "/laftel 명령어로 라프텔 애니 편성표와 랭킹을 확인할 수 있습니다."
 
 # Resources
 

--- a/tests/test_laftel.py
+++ b/tests/test_laftel.py
@@ -36,6 +36,8 @@ def _make_service(**overrides):
         svc.bot = MagicMock()
         svc._schedule_cache = None
         svc._last_fetch_time = None
+        svc._ranking_cache = {}
+        svc._ranking_fetch_time = {}
         for k, v in overrides.items():
             setattr(svc, k, v)
         return svc
@@ -269,3 +271,135 @@ class TestHandleLaftelCallback:
         args = svc.bot.send_message.call_args
         assert args[0][0] == 123
         assert args[0][1] == strings.laftel_portal_msg
+
+    def test_menu_ranking_shows_weekly(self):
+        svc = _make_service()
+        svc._get_ranking = MagicMock(return_value="주간 랭킹")
+
+        call = MagicMock()
+        call.data = "laftel_menu:ranking"
+        call.message.chat.id = 1
+        call.message.message_id = 1
+
+        svc.handle_laftel_callback(call)
+
+        svc._get_ranking.assert_called_once_with("week")
+        svc.bot.edit_message_text.assert_called_once()
+        assert svc.bot.edit_message_text.call_args[1]["reply_markup"] is not None
+
+    def test_ranking_type_shows_formatted_text(self):
+        cache = {
+            "quarter": [
+                LaftelAnime(id=1, name="테스트 애니", genres=["액션"], content_rating="15세 이용가"),
+            ]
+        }
+        svc = _make_service(_ranking_cache=cache, _ranking_fetch_time={"quarter": datetime.datetime.now()})
+
+        call = MagicMock()
+        call.data = "laftel_ranking:quarter"
+        call.message.chat.id = 1
+        call.message.message_id = 1
+
+        svc.handle_laftel_callback(call)
+
+        args = svc.bot.edit_message_text.call_args
+        assert "테스트 애니" in args[0][0]
+        assert "1." in args[0][0]
+
+
+class TestFetchRanking:
+    @patch("modules.laftel.requests.get")
+    def test_success(self, mock_get):
+        import json
+
+        sample = [{"id": 1, "name": "테스트", "genres": ["액션"], "content_rating": "15세 이용가"}]
+        response = MagicMock()
+        response.content = json.dumps(sample).encode()
+        mock_get.return_value = response
+
+        svc = _make_service()
+        svc._fetch_ranking("week")
+
+        assert "week" in svc._ranking_cache
+        assert len(svc._ranking_cache["week"]) == 1
+        assert svc._ranking_fetch_time["week"] is not None
+
+    @patch("modules.laftel.requests.get")
+    def test_api_failure_sets_empty_list(self, mock_get):
+        mock_get.side_effect = Exception("connection error")
+
+        svc = _make_service()
+        svc._fetch_ranking("week")
+
+        assert svc._ranking_cache["week"] == []
+
+    @patch("modules.laftel.requests.get")
+    def test_stale_cache_preserved_on_error(self, mock_get):
+        mock_get.side_effect = Exception("timeout")
+        old_cache = [LaftelAnime(id=1, name="old")]
+
+        svc = _make_service(
+            _ranking_cache={"week": old_cache},
+            _ranking_fetch_time={"week": datetime.datetime(2020, 1, 1)},
+        )
+        svc._fetch_ranking("week")
+
+        assert svc._ranking_cache["week"] is old_cache
+
+    @patch("modules.laftel.requests.get")
+    def test_cache_not_expired_skips_fetch(self, mock_get):
+        svc = _make_service(
+            _ranking_cache={"week": []},
+            _ranking_fetch_time={"week": datetime.datetime.now() - datetime.timedelta(seconds=100)},
+        )
+        svc._fetch_ranking("week")
+
+        mock_get.assert_not_called()
+
+
+class TestGetRanking:
+    def test_normal_output(self):
+        items = [
+            LaftelAnime(id=1, name="애니A", genres=["액션"], content_rating="15세 이용가", is_laftel_only=True),
+            LaftelAnime(id=2, name="애니B", genres=["로맨스"], content_rating="성인 이용가", is_ending=True),
+        ]
+        svc = _make_service(
+            _ranking_cache={"week": items},
+            _ranking_fetch_time={"week": datetime.datetime.now()},
+        )
+        result = svc._get_ranking("week")
+
+        assert "주간 랭킹" in result
+        assert "1." in result
+        assert "2." in result
+        assert "애니A" in result
+        assert "애니B" in result
+        assert "15+" in result
+        assert "19+" in result
+        assert "독점" in result
+        assert "총 2개" in result
+
+    def test_empty_ranking(self):
+        svc = _make_service(
+            _ranking_cache={"week": []},
+            _ranking_fetch_time={"week": datetime.datetime.now()},
+        )
+        result = svc._get_ranking("week")
+        assert result == strings.laftel_ranking_empty_msg
+
+
+class TestBuildRankingKeyboard:
+    def test_has_all_types(self):
+        keyboard = LaftelService._build_ranking_type_keyboard()
+        buttons = [btn for row in keyboard.keyboard for btn in row]
+        callback_data_set = {btn.callback_data for btn in buttons}
+
+        assert "laftel_ranking:week" in callback_data_set
+        assert "laftel_ranking:quarter" in callback_data_set
+        assert "laftel_ranking:history" in callback_data_set
+        assert len(buttons) == 3
+
+    def test_portal_has_ranking_button(self):
+        keyboard = LaftelService._build_portal_keyboard()
+        buttons = [btn for row in keyboard.keyboard for btn in row]
+        assert any(btn.callback_data == "laftel_menu:ranking" for btn in buttons)

--- a/tests/test_laftel.py
+++ b/tests/test_laftel.py
@@ -1,4 +1,5 @@
 import datetime
+import time
 from unittest.mock import MagicMock, patch
 
 from modules.api_models import LaftelAnime
@@ -38,6 +39,7 @@ def _make_service(**overrides):
         svc._last_fetch_time = None
         svc._ranking_cache = {}
         svc._ranking_fetch_time = {}
+        svc._pending_search = None
         for k, v in overrides.items():
             setattr(svc, k, v)
         return svc
@@ -403,3 +405,120 @@ class TestBuildRankingKeyboard:
         keyboard = LaftelService._build_portal_keyboard()
         buttons = [btn for row in keyboard.keyboard for btn in row]
         assert any(btn.callback_data == "laftel_menu:ranking" for btn in buttons)
+
+    def test_portal_has_search_button(self):
+        keyboard = LaftelService._build_portal_keyboard()
+        buttons = [btn for row in keyboard.keyboard for btn in row]
+        assert any(btn.callback_data == "laftel_menu:search" for btn in buttons)
+
+
+class TestSearch:
+    @patch("modules.laftel.requests.get")
+    def test_search_returns_results(self, mock_get):
+        import json
+
+        sample = {
+            "count": 1,
+            "results": [{"id": 1, "name": "테스트 애니", "genres": ["액션"], "content_rating": "15세 이용가"}],
+        }
+        response = MagicMock()
+        response.content = json.dumps(sample).encode()
+        mock_get.return_value = response
+
+        svc = _make_service()
+        result = svc._search("테스트")
+
+        assert "테스트 애니" in result
+        assert "1." in result
+        assert "총 1개" in result
+
+    @patch("modules.laftel.requests.get")
+    def test_search_empty_result(self, mock_get):
+        import json
+
+        response = MagicMock()
+        response.content = json.dumps({"count": 0, "results": []}).encode()
+        mock_get.return_value = response
+
+        svc = _make_service()
+        result = svc._search("존재하지않는키워드")
+
+        assert strings.laftel_search_empty_msg.format("존재하지않는키워드") == result
+
+    @patch("modules.laftel.requests.get")
+    def test_search_api_failure(self, mock_get):
+        mock_get.side_effect = Exception("connection error")
+
+        svc = _make_service()
+        result = svc._search("테스트")
+
+        assert result == strings.laftel_error_msg
+
+
+class TestHandleSearchReply:
+    def test_valid_reply_triggers_search(self):
+        svc = _make_service()
+        svc._search = MagicMock(return_value="검색 결과")
+        svc._pending_search = (1, 1, time.time())
+
+        msg = MagicMock()
+        msg.from_user.id = 1
+        msg.chat.id = 1
+        msg.text = "프리렌"
+
+        svc.handle_search_reply(msg)
+
+        svc._search.assert_called_once_with("프리렌")
+        svc.bot.reply_to.assert_called_once()
+
+    def test_no_pending_search_ignored(self):
+        svc = _make_service()
+
+        msg = MagicMock()
+        msg.from_user.id = 1
+        msg.chat.id = 1
+        msg.text = "프리렌"
+
+        svc.handle_search_reply(msg)
+        svc.bot.reply_to.assert_not_called()
+
+    def test_wrong_user_ignored(self):
+        svc = _make_service()
+        svc._pending_search = (1, 1, time.time())
+
+        msg = MagicMock()
+        msg.from_user.id = 999
+        msg.chat.id = 1
+        msg.text = "프리렌"
+
+        svc.handle_search_reply(msg)
+        svc.bot.reply_to.assert_not_called()
+
+    def test_expired_search_ignored(self):
+        svc = _make_service()
+        svc._pending_search = (1, 1, time.time() - 600)
+
+        msg = MagicMock()
+        msg.from_user.id = 1
+        msg.chat.id = 1
+        msg.text = "프리렌"
+
+        svc.handle_search_reply(msg)
+        svc.bot.reply_to.assert_not_called()
+        assert svc._pending_search is None
+
+    def test_menu_search_sends_force_reply(self):
+        svc = _make_service()
+
+        call = MagicMock()
+        call.data = "laftel_menu:search"
+        call.from_user.id = 1
+        call.message.chat.id = 1
+        call.message.message_id = 1
+
+        svc.handle_laftel_callback(call)
+
+        svc.bot.send_message.assert_called_once()
+        args = svc.bot.send_message.call_args
+        assert args[0][1] == strings.laftel_search_input_msg
+        assert svc._pending_search is not None

--- a/tests/test_laftel.py
+++ b/tests/test_laftel.py
@@ -507,6 +507,31 @@ class TestHandleSearchReply:
         svc.bot.reply_to.assert_not_called()
         assert svc._pending_search is None
 
+    def test_empty_keyword_sends_guidance(self):
+        svc = _make_service()
+        svc._pending_search = (1, 1, time.time())
+
+        msg = MagicMock()
+        msg.from_user.id = 1
+        msg.chat.id = 1
+        msg.text = "   "
+
+        svc.handle_search_reply(msg)
+
+        svc.bot.reply_to.assert_called_once_with(msg, strings.laftel_search_empty_input_msg)
+
+    def test_wrong_chat_ignored(self):
+        svc = _make_service()
+        svc._pending_search = (1, 1, time.time())
+
+        msg = MagicMock()
+        msg.from_user.id = 1
+        msg.chat.id = 999
+        msg.text = "프리렌"
+
+        svc.handle_search_reply(msg)
+        svc.bot.reply_to.assert_not_called()
+
     def test_menu_search_sends_force_reply(self):
         svc = _make_service()
 
@@ -522,3 +547,85 @@ class TestHandleSearchReply:
         args = svc.bot.send_message.call_args
         assert args[0][1] == strings.laftel_search_input_msg
         assert svc._pending_search is not None
+
+
+class TestFormatEntry:
+    def test_with_null_fields(self):
+        from modules.laftel import _format_entry
+
+        item = LaftelAnime(id=1, name=None, genres=None, content_rating=None, is_ending=None)
+        result = _format_entry(item)
+        assert "laftel.net/item/1" in result
+
+    def test_with_rank(self):
+        from modules.laftel import _format_entry
+
+        item = LaftelAnime(id=1, name="테스트", genres=["액션"], content_rating="15세 이용가")
+        result = _format_entry(item, rank=3)
+        assert "3." in result
+        assert "테스트" in result
+
+    def test_without_rank(self):
+        from modules.laftel import _format_entry
+
+        item = LaftelAnime(id=1, name="테스트", genres=["액션"], content_rating="15세 이용가")
+        result = _format_entry(item)
+        assert "테스트" in result
+        assert "1." not in result
+
+
+class TestEdgeCases:
+    def test_invalid_schedule_day_code_ignored(self):
+        svc = _make_service()
+        call = MagicMock()
+        call.data = "laftel_schedule:invalid"
+        call.message.chat.id = 1
+        call.message.message_id = 1
+
+        svc.handle_laftel_callback(call)
+        svc.bot.edit_message_text.assert_not_called()
+
+    def test_invalid_ranking_type_ignored(self):
+        svc = _make_service()
+        call = MagicMock()
+        call.data = "laftel_ranking:invalid"
+        call.message.chat.id = 1
+        call.message.message_id = 1
+
+        svc.handle_laftel_callback(call)
+        svc.bot.edit_message_text.assert_not_called()
+
+    def test_laftel_ranking_callback_detected(self):
+        assert LaftelService.is_laftel_callback("laftel_ranking:week") is True
+        assert LaftelService.is_laftel_callback("laftel_ranking:quarter") is True
+
+    def test_search_result_keyboard_has_buttons(self):
+        keyboard = LaftelService._build_search_result_keyboard()
+        buttons = [btn for row in keyboard.keyboard for btn in row]
+        callback_data_set = {btn.callback_data for btn in buttons}
+        assert "laftel_menu:search" in callback_data_set
+        assert "laftel_menu:portal" in callback_data_set
+        assert len(buttons) == 2
+
+    @patch("modules.laftel.requests.get")
+    def test_search_truncation_on_many_results(self, mock_get):
+        import json
+
+        results = [
+            {
+                "id": i,
+                "name": f"매우 긴 제목의 애니메이션 작품 {i}",
+                "genres": ["장르A", "장르B"],
+                "content_rating": "15세 이용가",
+            }
+            for i in range(100)
+        ]
+        response = MagicMock()
+        response.content = json.dumps({"count": 100, "results": results}).encode()
+        mock_get.return_value = response
+
+        svc = _make_service()
+        result = svc._search("테스트")
+
+        assert len(result) <= 4096
+        assert strings.laftel_schedule_truncated_msg in result


### PR DESCRIPTION
## Summary
- `/laftel` 포털에 주간/분기/역대 랭킹 기능 추가
- ForceReply 기반 키워드 검색 기능 추가
- API nullable 필드 방어 및 UX 개선

## Changes
### New Features
- **랭킹**: 포털에서 "랭킹" 탭 → 주간 Top 20 바로 표시, [주간]/[분기]/[역대] 타입 전환 키보드
- **검색**: 포털에서 "검색" 탭 → ForceReply로 키워드 입력 → 검색 결과 + [다시 검색]/[포털로] 키보드
- `LaftelSearchResponse` pydantic 래퍼 모델 추가

### Bug Fixes
- `LaftelAnime` 모델의 nullable 필드 방어 (`str | None`, `list | None`, `bool | None`)
- 빈 키워드 입력 시 안내 메시지 전송

### Refactoring
- 편성표/랭킹/검색의 중복 포맷팅 로직을 `_format_entry` 헬퍼로 통합

### Test
- Laftel 테스트 48건 (기존 19건 + 신규 29건)
- 엣지 케이스: null 필드, 빈 키워드, wrong user/chat, 타임아웃, 유효하지 않은 코드, truncation

## Test plan
- [x] ruff check / ruff format 통과
- [x] pytest 348 passed
- [x] 로컬 Docker 빌드 및 텔레그램 실제 동작 확인