### PR TITLE
Enforce code conventions and reduce duplication

### DIFF
--- a/bin/handlers.py
+++ b/bin/handlers.py
@@ -103,14 +103,17 @@ def register_handlers(bot, hub, logger):
 
     # Russian roulette
     @bot.message_handler(commands=["roulette"])
+    @safe_handler
     def handle_roulette(message):
         bot.send_message(message.chat.id, hub.random_based_features.russian_roulette(message.chat.id, message.text))
 
     @bot.message_handler(commands=["shoot"])
+    @safe_handler
     def handle_shoot(message):
         bot.send_message(message.chat.id, hub.random_based_features.trig_bullet(message.chat.id))
 
     @bot.message_handler(commands=["flush_bullet"])
+    @safe_handler
     def handle_flush_bullet(message):
         bot.send_message(message.chat.id, hub.random_based_features.russian_roulette(message.chat.id, "roulette 0 0"))
 
@@ -127,6 +130,7 @@ def register_handlers(bot, hub, logger):
 
     # Calculator
     @bot.message_handler(commands=["calc"])
+    @safe_handler
     def handle_calc(message):
         hub.calculator_handler(message)
 
@@ -145,6 +149,7 @@ def register_handlers(bot, hub, logger):
         hub.ask_handler(message)
 
     @bot.message_handler(commands=["clear_chat"])
+    @safe_handler
     def handle_clear_chat(message):
         hub.clear_chat_handler(message)
 
@@ -156,14 +161,17 @@ def register_handlers(bot, hub, logger):
 
     # Admin commands
     @bot.message_handler(commands=["allow_chat"])
+    @safe_handler
     def handle_allow_chat(message):
         hub.allow_chat_handler(message)
 
     @bot.message_handler(commands=["deny_chat"])
+    @safe_handler
     def handle_deny_chat(message):
         hub.deny_chat_handler(message)
 
     @bot.message_handler(commands=["ask_settings"])
+    @safe_handler
     def handle_ask_settings(message):
         hub.ask_settings_handler(message)
 
@@ -181,6 +189,7 @@ def register_handlers(bot, hub, logger):
 
     # ForceReply handler for custom prompt input
     @bot.message_handler(func=lambda m: m.reply_to_message and m.reply_to_message.text == strings.set_prompt_input_msg)
+    @safe_handler
     def handle_prompt_reply(message):
         hub.handle_prompt_reply(message)
 
@@ -188,6 +197,7 @@ def register_handlers(bot, hub, logger):
     @bot.message_handler(
         func=lambda m: m.reply_to_message and m.reply_to_message.text == strings.laftel_search_input_msg
     )
+    @safe_handler
     def handle_laftel_search_reply(message):
         hub.laftel.handle_search_reply(message)
 

--- a/modules/features_hub.py
+++ b/modules/features_hub.py
@@ -146,28 +146,37 @@ class BotFeaturesHub:
         question = text[len(command) :].strip()
         language_code = getattr(message.from_user, "language_code", None)
 
-        image = None
-        context = None
-        photo_list = getattr(message, "photo", None)
-        reply = getattr(message, "reply_to_message", None)
-        if photo_list:
-            image = self._download_photo(photo_list)
-            if image is None:
-                self.bot.reply_to(message, strings.ask_photo_download_error_msg)
-                return
-        elif reply:
-            reply_photo = getattr(reply, "photo", None)
-            if reply_photo:
-                image = self._download_photo(reply_photo)
-                if image is None:
-                    self.bot.reply_to(message, strings.ask_photo_download_error_msg)
-                    return
-            context = getattr(reply, "text", None) or getattr(reply, "caption", None)
+        image, context = self._extract_ask_params(message)
+        if image is False:
+            self.bot.reply_to(message, strings.ask_photo_download_error_msg)
+            return
 
         self.bot.send_chat_action(message.chat.id, "typing")
         result = self.gemini_chat.ask(message.chat.id, message.from_user.id, question, language_code, context, image)
         for chunk in result:
             self._reply_markdown(message, chunk)
+
+    def _extract_ask_params(self, message):
+        """메시지에서 이미지와 컨텍스트를 추출한다. 사진 다운로드 실패 시 (False, None)을 반환."""
+        photo_list = getattr(message, "photo", None)
+        reply = getattr(message, "reply_to_message", None)
+
+        if photo_list:
+            image = self._download_photo(photo_list)
+            return (image, None) if image is not None else (False, None)
+
+        if reply:
+            reply_photo = getattr(reply, "photo", None)
+            if reply_photo:
+                image = self._download_photo(reply_photo)
+                if image is None:
+                    return False, None
+            else:
+                image = None
+            context = getattr(reply, "text", None) or getattr(reply, "caption", None)
+            return image, context
+
+        return None, None
 
     def _download_photo(self, photo_list):
         try:
@@ -199,8 +208,8 @@ class BotFeaturesHub:
 
     # Handling ordinary message
     def ordinary_message(self, message):
-        if ("수온" in message.text) or ("자살" in message.text):
+        if any(kw in message.text for kw in strings.temp_keywords):
             self.bot.reply_to(message, self.get_temp())
 
-        if ("마법의 소라고둥" in message.text) or ("마법의 소라고동" in message.text):
+        if any(kw in message.text for kw in strings.magic_conch_keywords):
             self.bot.reply_to(message, self.random_based_features.magic_conch())

--- a/modules/laftel.py
+++ b/modules/laftel.py
@@ -186,6 +186,22 @@ class LaftelService:
             reply_markup=self._build_portal_keyboard(),
         )
 
+    # --- 유틸리티 ---
+
+    @staticmethod
+    def _truncate_message(header, entries, footer):
+        """메시지가 MAX_MESSAGE_LENGTH를 초과하면 항목을 잘라서 반환한다."""
+        text = header + "".join(entries) + footer
+        if len(text) > MAX_MESSAGE_LENGTH:
+            truncated = header
+            for entry in entries:
+                remaining = len(footer) + len(strings.laftel_schedule_truncated_msg)
+                if len(truncated) + len(entry) + remaining > MAX_MESSAGE_LENGTH:
+                    break
+                truncated += entry
+            text = truncated + strings.laftel_schedule_truncated_msg + "\n" + footer
+        return text
+
     # --- 키보드 ---
 
     @staticmethod
@@ -249,20 +265,9 @@ class LaftelService:
 
         header = strings.laftel_schedule_header_msg.format(day_name)
         entries = [_format_entry(item) for item in items]
-
         footer = strings.laftel_schedule_footer_msg.format(len(items))
-        text = header + "".join(entries) + footer
 
-        if len(text) > MAX_MESSAGE_LENGTH:
-            truncated = header
-            for entry in entries:
-                remaining = len(footer) + len(strings.laftel_schedule_truncated_msg)
-                if len(truncated) + len(entry) + remaining > MAX_MESSAGE_LENGTH:
-                    break
-                truncated += entry
-            text = truncated + strings.laftel_schedule_truncated_msg + "\n" + footer
-
-        return text
+        return self._truncate_message(header, entries, footer)
 
     # --- 랭킹 데이터 ---
 
@@ -298,20 +303,9 @@ class LaftelService:
 
         header = strings.laftel_ranking_header_msg.format(type_label)
         entries = [_format_entry(item, rank=rank) for rank, item in enumerate(items, 1)]
-
         footer = strings.laftel_ranking_footer_msg.format(len(items))
-        text = header + "".join(entries) + footer
 
-        if len(text) > MAX_MESSAGE_LENGTH:
-            truncated = header
-            for entry in entries:
-                remaining = len(footer) + len(strings.laftel_schedule_truncated_msg)
-                if len(truncated) + len(entry) + remaining > MAX_MESSAGE_LENGTH:
-                    break
-                truncated += entry
-            text = truncated + strings.laftel_schedule_truncated_msg + "\n" + footer
-
-        return text
+        return self._truncate_message(header, entries, footer)
 
     @staticmethod
     def _build_ranking_type_keyboard():
@@ -367,17 +361,6 @@ class LaftelService:
 
         header = strings.laftel_search_header_msg.format(_escape_markdown(keyword))
         entries = [_format_entry(item, rank=rank) for rank, item in enumerate(items, 1)]
-
         footer = strings.laftel_search_footer_msg.format(len(items))
-        text = header + "".join(entries) + footer
 
-        if len(text) > MAX_MESSAGE_LENGTH:
-            truncated = header
-            for entry in entries:
-                remaining = len(footer) + len(strings.laftel_schedule_truncated_msg)
-                if len(truncated) + len(entry) + remaining > MAX_MESSAGE_LENGTH:
-                    break
-                truncated += entry
-            text = truncated + strings.laftel_schedule_truncated_msg + "\n" + footer
-
-        return text
+        return self._truncate_message(header, entries, footer)

--- a/resources/strings.py
+++ b/resources/strings.py
@@ -68,6 +68,10 @@ shot_blind_msg = "이번 격발 결과는 공포탄입니다."
 # coin toss message
 coin_toss_prefix_msg = "동전뒤집기 결과 : "
 
+# keyword triggers
+temp_keywords = ("수온", "자살")
+magic_conch_keywords = ("마법의 소라고둥", "마법의 소라고동")
+
 # suon (river temperature) message
 suon_maintenance_status = "점검중"
 suon_unavailable_msg = "현재 한강 수온 정보를 가져올 수 없습니다. (사유: 정보 미제공)"


### PR DESCRIPTION
## Summary
- 코드 컨벤션 위반(문자열 하드코딩, @safe_handler 누락) 수정
- laftel.py 메시지 truncation 중복 로직 추출
- ask_handler 메서드 관심사 분리

## Changes
### Refactoring
- 하드코딩된 한국어 키워드(`수온`, `자살`, `마법의 소라고둥` 등)를 `resources/strings.py`로 이동
- 예외 가능 핸들러 10개에 `@safe_handler` 데코레이터 추가 (roulette, shoot, flush_bullet, calc, clear_chat, allow_chat, deny_chat, ask_settings, prompt_reply, laftel_search_reply)
- `LaftelService`에 `_truncate_message()` 정적 메서드 추출하여 3곳의 동일 블록 제거
- `BotFeaturesHub.ask_handler()`에서 이미지/컨텍스트 추출 로직을 `_extract_ask_params()`로 분리

## Test plan
- [x] ruff check + ruff format --check 통과
- [x] pytest 348 tests passed