### PR TITLE
Add RSSF token auth and RSS handler with review fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -88,6 +88,8 @@ jobs:
             SEOUL_HANGANG_WATER_TOKEN=${{ secrets.SEOUL_HANGANG_WATER_TOKEN }}
             GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }}
             ADMIN_USER_ID=${{ secrets.ADMIN_USER_ID }}
+            RSSF_TOKEN=${{ secrets.RSSF_TOKEN }}
+            RSSF_URL=${{ secrets.RSSF_URL }}
             EOF
             mkdir -p ~/sungsimdangbot/data
             docker compose pull

--- a/bin/handlers.py
+++ b/bin/handlers.py
@@ -179,7 +179,6 @@ def register_handlers(bot, hub, logger):
     @bot.message_handler(commands=["bfrss"])
     @safe_handler
     def handle_bfrss(message):
-        print(f"[DEBUG] /bfrss called by {message.chat.id}", flush=True)
         hub.rss_handler(message)
 
     # Location

--- a/bin/handlers.py
+++ b/bin/handlers.py
@@ -200,7 +200,6 @@ def register_handlers(bot, hub, logger):
     def handle_laftel_search_reply(message):
         hub.laftel.handle_search_reply(message)
 
-
     # Ordinary message
     @bot.message_handler(content_types=["text"])
     @safe_handler

--- a/bin/handlers.py
+++ b/bin/handlers.py
@@ -15,6 +15,7 @@ QUERY_STRINGS = {
     "search": strings.search_help_msg,
     "namu": strings.namu_help_msg,
     "laftel": strings.laftel_help_msg,
+    "bfrss": strings.bfrss_help_msg,
 }
 
 
@@ -37,6 +38,7 @@ def register_commands(bot):
             telebot.types.BotCommand("myid", "내 사용자 ID 확인"),
             telebot.types.BotCommand("ping", "봇 상태 확인"),
             telebot.types.BotCommand("laftel", "라프텔 애니 정보"),
+            telebot.types.BotCommand("bfrss", "해외 rss 번역수신"),
         ]
     )
 
@@ -173,6 +175,13 @@ def register_handlers(bot, hub, logger):
     def handle_dday(message):
         hub.d_day(message)
 
+    # Send translated RSS feed to FASTAPI server
+    @bot.message_handler(commands=["bfrss"])
+    @safe_handler
+    def handle_bfrss(message):
+        print(f"[DEBUG] /bfrss called by {message.chat.id}", flush=True)
+        hub.rss_handler(message)
+
     # Location
     @bot.message_handler(content_types=["location"])
     @safe_handler
@@ -190,6 +199,7 @@ def register_handlers(bot, hub, logger):
     )
     def handle_laftel_search_reply(message):
         hub.laftel.handle_search_reply(message)
+
 
     # Ordinary message
     @bot.message_handler(content_types=["text"])

--- a/config/config.py
+++ b/config/config.py
@@ -30,6 +30,10 @@ GEMINI_RATE_LIMIT = _int_env("GEMINI_RATE_LIMIT", 5)
 GEMINI_API_TIMEOUT = _int_env("GEMINI_API_TIMEOUT", 60)
 ADMIN_USER_ID = _int_env("ADMIN_USER_ID", 0)
 
+# External AI Engine API & endpoints
+RSSF_TOKEN = os.getenv("RSSF_TOKEN", "")
+RSSF_URL = os.getenv("RSSF_URL", "")
+
 # External endpoints
 NAMUWIKI_BASE_URL = "https://namu.wiki/w/"
 SEARCH_BASE_URL = "https://dapi.kakao.com/v2/search/web?"

--- a/config/config.py
+++ b/config/config.py
@@ -30,7 +30,7 @@ GEMINI_RATE_LIMIT = _int_env("GEMINI_RATE_LIMIT", 5)
 GEMINI_API_TIMEOUT = _int_env("GEMINI_API_TIMEOUT", 60)
 ADMIN_USER_ID = _int_env("ADMIN_USER_ID", 0)
 
-# External AI Engine API & endpoints
+# RSS feed translator API
 RSSF_TOKEN = os.getenv("RSSF_TOKEN", "")
 RSSF_URL = os.getenv("RSSF_URL", "")
 

--- a/modules/api_models.py
+++ b/modules/api_models.py
@@ -94,3 +94,18 @@ class LaftelSearchResponse(BaseModel):
 
     count: int = 0
     results: list[LaftelAnime] = []
+
+
+# --- RSS Feed (FastAPI) ---
+
+
+class RssfEntry(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    title: str = ""
+    link: str = ""
+
+
+class RssfResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    date: str = ""
+    entries: list[RssfEntry] = []

--- a/modules/features_hub.py
+++ b/modules/features_hub.py
@@ -192,6 +192,11 @@ class BotFeaturesHub:
             for plain_chunk in GeminiChat.split_response(text):
                 self.bot.reply_to(message, plain_chunk)
 
+    # RSS JSON request
+    def rss_handler(self, message):
+       text, parse_mode = self.web_manager.rss_handler(message)
+       self.bot.reply_to(message, text, parse_mode=parse_mode)
+
     # Clear chat
     def clear_chat_handler(self, message):
         self.gemini_chat.clear_session(message.chat.id, message.from_user.id)

--- a/modules/features_hub.py
+++ b/modules/features_hub.py
@@ -194,8 +194,8 @@ class BotFeaturesHub:
 
     # RSS JSON request
     def rss_handler(self, message):
-       text, parse_mode = self.web_manager.rss_handler(message)
-       self.bot.reply_to(message, text, parse_mode=parse_mode)
+        text, parse_mode = self.web_manager.rss_handler(message)
+        self.bot.reply_to(message, text, parse_mode=parse_mode)
 
     # Clear chat
     def clear_chat_handler(self, message):

--- a/modules/web_based.py
+++ b/modules/web_based.py
@@ -145,7 +145,7 @@ class WebManager:
             res = requests.get(config.RSSF_URL, params={"token": config.RSSF_TOKEN}, timeout=10)
             data = res.json()
             text = f" HACKER NEWS ({data['date'][4:6]}월 {data['date'][6:]}일)\n\n"
-            text += "\n".join(f"• <a href=\"{e['link']}\">{e['title']}</a>" for e in data['entries'])
+            text += "\n".join(f'• <a href="{e["link"]}">{e["title"]}</a>' for e in data["entries"])
             return text, "HTML"
         except Exception as e:
             logger.log_error(f"rss_handler failed: {e}")

--- a/modules/web_based.py
+++ b/modules/web_based.py
@@ -148,8 +148,7 @@ class WebManager:
             data = RssfResponse.model_validate_json(res.text)
             text = f" HACKER NEWS ({data.date[4:6]}??{data.date[6:]}??\n\n"
             text += "\n".join(
-                f'??<a href="{html.escape(e.link, quote=True)}">{html.escape(e.title)}</a>'
-                for e in data.entries
+                f'??<a href="{html.escape(e.link, quote=True)}">{html.escape(e.title)}</a>' for e in data.entries
             )
             return text, "HTML"
         except Exception as e:

--- a/modules/web_based.py
+++ b/modules/web_based.py
@@ -1,4 +1,5 @@
 import datetime
+import html
 import urllib.parse
 
 import requests
@@ -9,6 +10,7 @@ from modules.api_models import (
     HangangWaterResponse,
     KakaoAddressResponse,
     KakaoSearchResponse,
+    RssfResponse,
     WeatherResponse,
 )
 from modules.utils import extract_command_args, strip_html_tags
@@ -143,10 +145,13 @@ class WebManager:
     def rss_handler(self, message):
         try:
             res = requests.get(config.RSSF_URL, params={"token": config.RSSF_TOKEN}, timeout=10)
-            data = res.json()
-            text = f" HACKER NEWS ({data['date'][4:6]}월 {data['date'][6:]}일)\n\n"
-            text += "\n".join(f'• <a href="{e["link"]}">{e["title"]}</a>' for e in data["entries"])
+            data = RssfResponse.model_validate_json(res.text)
+            text = f" HACKER NEWS ({data.date[4:6]}월 {data.date[6:]}일)\n\n"
+            text += "\n".join(
+                f'• <a href="{html.escape(e.link, quote=True)}">{html.escape(e.title)}</a>'
+                for e in data.entries
+            )
             return text, "HTML"
         except Exception as e:
             logger.log_error(f"rss_handler failed: {e}")
-            return strings.rss_error_msg, None
+            return strings.bfrss_error_msg, None

--- a/modules/web_based.py
+++ b/modules/web_based.py
@@ -139,3 +139,14 @@ class WebManager:
         if self.suon_v2 is None:
             return strings.suon_maintenance_status
         return self.suon_v2
+
+    def rss_handler(self, message):
+        try:
+            res = requests.get(config.RSSF_URL, params={"token": config.RSSF_TOKEN}, timeout=10)
+            data = res.json()
+            text = f" HACKER NEWS ({data['date'][4:6]}월 {data['date'][6:]}일)\n\n"
+            text += "\n".join(f"• <a href=\"{e['link']}\">{e['title']}</a>" for e in data['entries'])
+            return text, "HTML"
+        except Exception as e:
+            logger.log_error(f"rss_handler failed: {e}")
+            return strings.rss_error_msg, None

--- a/modules/web_based.py
+++ b/modules/web_based.py
@@ -26,12 +26,12 @@ WEATHER_BASE_URL = "https://api.openweathermap.org/data/2.5/weather?"
 SUON_REFRESH_INTERVAL = 600  # seconds
 
 
-# 강물 온도 조회
+# 媛뺣Ъ ?⑤룄 議고쉶
 class WebManager:
     # init
     def __init__(self):
         self.suon_v2 = None
-        # Records current time and latest update 현재 시간과 마지막 업데이트 시점을 기록
+        # Records current time and latest update ?꾩옱 ?쒓컙怨?留덉?留??낅뜲?댄듃 ?쒖젏??湲곕줉
         self.current_time = datetime.datetime.now()
         self.last_update_time = datetime.datetime(
             self.current_time.year, self.current_time.month, self.current_time.day, self.current_time.hour, 1
@@ -39,12 +39,12 @@ class WebManager:
         if self.current_time.minute == 0:
             self.last_update_time -= datetime.timedelta(hours=1)
 
-        # Initialize current temperature information 현재 온도 정보를 최초 설정
+        # Initialize current temperature information ?꾩옱 ?⑤룄 ?뺣낫瑜?理쒖큹 ?ㅼ젙
         self.update_suon()
 
-    # Update current temperature data 현재 온도 정보를 업데이트
+    # Update current temperature data ?꾩옱 ?⑤룄 ?뺣낫瑜??낅뜲?댄듃
     def update_suon(self):
-        # check recently update temperature info 최근에 업데이트하였는지 확인
+        # check recently update temperature info 理쒓렐???낅뜲?댄듃?섏??붿? ?뺤씤
         self.current_time = datetime.datetime.now()
         interval = (self.current_time - self.last_update_time).total_seconds()
 
@@ -122,8 +122,8 @@ class WebManager:
         weather_data = WeatherResponse.model_validate_json(weather_request.text)
 
         weather = weather_data.weather[0].description
-        temp = str(round(weather_data.main.temp - 273.15)) + "°C"
-        feels_temp = str(round(weather_data.main.feels_like - 273.15)) + "°C"
+        temp = str(round(weather_data.main.temp - 273.15)) + "째C"
+        feels_temp = str(round(weather_data.main.feels_like - 273.15)) + "째C"
         humidity = str(round(weather_data.main.humidity)) + "%"
 
         weather_result = strings.geolocation_weather_msg.format(
@@ -136,7 +136,7 @@ class WebManager:
 
         return geo_location + "\n" + map_location + "\n\n" + weather_result
 
-    # Provide temperature data to other methods (V2, 한강으로 고정)
+    # Provide temperature data to other methods (V2, ?쒓컯?쇰줈 怨좎젙)
     def provide_suon_v2(self):
         if self.suon_v2 is None:
             return strings.suon_maintenance_status
@@ -146,9 +146,9 @@ class WebManager:
         try:
             res = requests.get(config.RSSF_URL, params={"token": config.RSSF_TOKEN}, timeout=10)
             data = RssfResponse.model_validate_json(res.text)
-            text = f" HACKER NEWS ({data.date[4:6]}월 {data.date[6:]}일)\n\n"
+            text = f" HACKER NEWS ({data.date[4:6]}??{data.date[6:]}??\n\n"
             text += "\n".join(
-                f'• <a href="{html.escape(e.link, quote=True)}">{html.escape(e.title)}</a>'
+                f'??<a href="{html.escape(e.link, quote=True)}">{html.escape(e.title)}</a>'
                 for e in data.entries
             )
             return text, "HTML"

--- a/resources/strings.py
+++ b/resources/strings.py
@@ -231,6 +231,10 @@ laftel_search_again_btn = "다시 검색"
 laftel_portal_btn = "포털로"
 laftel_help_msg = "/laftel 명령어로 라프텔 편성표, 랭킹, 검색 기능을 이용할 수 있습니다."
 
+# RSS feed translater message
+bfrss_help_msg = "번역된 rss를 보여줍니다. 주기는 오전 9시(딜레이 약 2분)에 갱신됩니다."
+bfrss_error_msg = "번역 서버에 연결할 수 없습니다."
+
 # Resources
 
 # Customized keyboards (inline)

--- a/tests/test_web_based.py
+++ b/tests/test_web_based.py
@@ -278,13 +278,15 @@ class TestRssHandler:
     @patch("modules.web_based.requests.get")
     def test_success(self, mock_get):
         response = MagicMock()
-        response.text = json.dumps({
-            "date": "20260424",
-            "entries": [
-                {"title": "Test Article", "link": "https://example.com"},
-                {"title": "Article with <special> &chars", "link": "https://example.com/path?a=1&b=2"},
-            ],
-        })
+        response.text = json.dumps(
+            {
+                "date": "20260424",
+                "entries": [
+                    {"title": "Test Article", "link": "https://example.com"},
+                    {"title": "Article with <special> &chars", "link": "https://example.com/path?a=1&b=2"},
+                ],
+            }
+        )
         mock_get.return_value = response
 
         with patch.object(WebManager, "__init__", lambda self: None):

--- a/tests/test_web_based.py
+++ b/tests/test_web_based.py
@@ -270,3 +270,40 @@ class TestProvideSuonV2:
             wm = WebManager()
             wm.suon_v2 = "23.5"
             assert wm.provide_suon_v2() == "23.5"
+
+
+class TestRssHandler:
+    @patch("modules.web_based.config.RSSF_URL", "http://test-server/hn")
+    @patch("modules.web_based.config.RSSF_TOKEN", "test_token")
+    @patch("modules.web_based.requests.get")
+    def test_success(self, mock_get):
+        response = MagicMock()
+        response.text = json.dumps({
+            "date": "20260424",
+            "entries": [
+                {"title": "Test Article", "link": "https://example.com"},
+                {"title": "Article with <special> &chars", "link": "https://example.com/path?a=1&b=2"},
+            ],
+        })
+        mock_get.return_value = response
+
+        with patch.object(WebManager, "__init__", lambda self: None):
+            wm = WebManager()
+            text, parse_mode = wm.rss_handler(MagicMock())
+            assert parse_mode == "HTML"
+            assert "HACKER NEWS" in text
+            assert "Test Article" in text
+            assert "&lt;special&gt;" in text
+            assert "&amp;chars" in text
+
+    @patch("modules.web_based.config.RSSF_URL", "http://test-server/hn")
+    @patch("modules.web_based.config.RSSF_TOKEN", "test_token")
+    @patch("modules.web_based.requests.get")
+    def test_server_failure(self, mock_get):
+        mock_get.side_effect = Exception("connection error")
+
+        with patch.object(WebManager, "__init__", lambda self: None):
+            wm = WebManager()
+            text, parse_mode = wm.rss_handler(MagicMock())
+            assert text == strings.bfrss_error_msg
+            assert parse_mode is None


### PR DESCRIPTION
## Summary
- RSSF 토큰 인증 기반 FastAPI 연동 추가 (config.py)
- rss_handler를 web_based.py WebManager 클래스로 이동
- features_hub.py에서 rss_handler 호출 방식 변경 (text, parse_mode 튜플 반환)
- cd.yml .env 생성 부분에 RSSF_TOKEN, RSSF_URL 추가

## Changes
### Bug Fixes
- `strings.rss_error_msg` → `strings.bfrss_error_msg` 수정 (AttributeError 방지)
- title/link에 `html.escape` 적용 (Telegram HTML parse_mode 400 에러 방지)

### Refactoring
- `res.json()` → `RssfResponse.model_validate_json()`으로 타입 안전 파싱
- `RssfEntry`, `RssfResponse` pydantic 모델 추가 (modules/api_models.py)
- bfrss 핸들러에서 debug print 제거

### Chore
- config.py RSSF 관련 주석 수정 (`# External AI Engine API` → `# RSS feed translator API`)

## Test plan
- [x] pytest 20개 전체 통과
- [x] ruff lint/format 통과
- [x] rss_handler 성공/실패 케이스 테스트 추가 (tests/test_web_based.py)
- [x] /bfrss 명령어 로컬 실행 확인