### PR TITLE
Fix mojibake corruption in web_based.py

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto eol=lf
+*.py text working-tree-encoding=UTF-8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,10 @@ repos:
     rev: v8.24.0
     hooks:
       - id: gitleaks
+  - repo: local
+    hooks:
+      - id: detect-mojibake
+        name: detect Korean mojibake (CP949 → UTF-8 corruption)
+        entry: scripts/detect_mojibake.py
+        language: system
+        types: [text]

--- a/modules/web_based.py
+++ b/modules/web_based.py
@@ -26,12 +26,12 @@ WEATHER_BASE_URL = "https://api.openweathermap.org/data/2.5/weather?"
 SUON_REFRESH_INTERVAL = 600  # seconds
 
 
-# 媛뺣Ъ ?⑤룄 議고쉶
+# 강물 온도 조회
 class WebManager:
     # init
     def __init__(self):
         self.suon_v2 = None
-        # Records current time and latest update ?꾩옱 ?쒓컙怨?留덉?留??낅뜲?댄듃 ?쒖젏??湲곕줉
+        # Records current time and latest update 현재 시간과 마지막 업데이트 시점을 기록
         self.current_time = datetime.datetime.now()
         self.last_update_time = datetime.datetime(
             self.current_time.year, self.current_time.month, self.current_time.day, self.current_time.hour, 1
@@ -39,12 +39,12 @@ class WebManager:
         if self.current_time.minute == 0:
             self.last_update_time -= datetime.timedelta(hours=1)
 
-        # Initialize current temperature information ?꾩옱 ?⑤룄 ?뺣낫瑜?理쒖큹 ?ㅼ젙
+        # Initialize current temperature information 현재 온도 정보를 최초 설정
         self.update_suon()
 
-    # Update current temperature data ?꾩옱 ?⑤룄 ?뺣낫瑜??낅뜲?댄듃
+    # Update current temperature data 현재 온도 정보를 업데이트
     def update_suon(self):
-        # check recently update temperature info 理쒓렐???낅뜲?댄듃?섏??붿? ?뺤씤
+        # check recently update temperature info 최근에 업데이트하였는지 확인
         self.current_time = datetime.datetime.now()
         interval = (self.current_time - self.last_update_time).total_seconds()
 
@@ -122,8 +122,8 @@ class WebManager:
         weather_data = WeatherResponse.model_validate_json(weather_request.text)
 
         weather = weather_data.weather[0].description
-        temp = str(round(weather_data.main.temp - 273.15)) + "째C"
-        feels_temp = str(round(weather_data.main.feels_like - 273.15)) + "째C"
+        temp = str(round(weather_data.main.temp - 273.15)) + "°C"
+        feels_temp = str(round(weather_data.main.feels_like - 273.15)) + "°C"
         humidity = str(round(weather_data.main.humidity)) + "%"
 
         weather_result = strings.geolocation_weather_msg.format(
@@ -136,7 +136,7 @@ class WebManager:
 
         return geo_location + "\n" + map_location + "\n\n" + weather_result
 
-    # Provide temperature data to other methods (V2, ?쒓컯?쇰줈 怨좎젙)
+    # Provide temperature data to other methods (V2, 한강으로 고정)
     def provide_suon_v2(self):
         if self.suon_v2 is None:
             return strings.suon_maintenance_status
@@ -146,9 +146,9 @@ class WebManager:
         try:
             res = requests.get(config.RSSF_URL, params={"token": config.RSSF_TOKEN}, timeout=10)
             data = RssfResponse.model_validate_json(res.text)
-            text = f" HACKER NEWS ({data.date[4:6]}??{data.date[6:]}??\n\n"
+            text = f" HACKER NEWS ({data.date[4:6]}월 {data.date[6:]}일)\n\n"
             text += "\n".join(
-                f'??<a href="{html.escape(e.link, quote=True)}">{html.escape(e.title)}</a>' for e in data.entries
+                f'• <a href="{html.escape(e.link, quote=True)}">{html.escape(e.title)}</a>' for e in data.entries
             )
             return text, "HTML"
         except Exception as e:

--- a/scripts/detect_mojibake.py
+++ b/scripts/detect_mojibake.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""CP949 → UTF-8 mojibake 검출 훅. 잘못된 인코딩으로 저장된 한국어 텍스트가 커밋되는 것을 막는다."""
+
+import re
+import sys
+
+# 정상 한국어에서는 거의 발생하지 않는 mojibake 시그니처:
+# - "째" + ASCII 알파벳: °C/°F가 깨진 형태
+# - "?" 직후 한글: CP949 바이트가 UTF-8로 디코딩될 때 흔한 패턴
+PATTERNS = [
+    (re.compile(r"째[A-Za-z]"), "단위 깨짐 (°C/°F가 CP949로 깨진 형태)"),
+    (re.compile(r"\?[가-힣]"), "물음표 뒤 한글 (CP949 mojibake)"),
+    (re.compile(r"\?\?[가-힣]"), "물음표 두 개 뒤 한글 (CP949 mojibake)"),
+]
+
+
+def main(paths: list[str]) -> int:
+    failed = False
+    for path in paths:
+        try:
+            with open(path, encoding="utf-8") as f:
+                lines = f.readlines()
+        except (UnicodeDecodeError, FileNotFoundError, IsADirectoryError):
+            continue
+
+        for lineno, line in enumerate(lines, start=1):
+            for pattern, label in PATTERNS:
+                if pattern.search(line):
+                    print(f"{path}:{lineno}: {label}: {line.rstrip()}")
+                    failed = True
+
+    if failed:
+        print("\nmojibake detected. 파일이 CP949/EUC-KR로 저장된 채 커밋되었을 수 있습니다.")
+        print("에디터 인코딩을 UTF-8로 다시 저장한 뒤 add → commit 하세요.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/test_web_based.py
+++ b/tests/test_web_based.py
@@ -297,6 +297,8 @@ class TestRssHandler:
             assert "Test Article" in text
             assert "&lt;special&gt;" in text
             assert "&amp;chars" in text
+            assert "04월 24일" in text
+            assert "•" in text
 
     @patch("modules.web_based.config.RSSF_URL", "http://test-server/hn")
     @patch("modules.web_based.config.RSSF_TOKEN", "test_token")


### PR DESCRIPTION
## Summary
- 53e8e7a 커밋에서 도입된 한글 mojibake 9곳 복원
- 인코딩 일관성 강제 + 자동 검출 훅으로 재발 방지

## Changes

### Bug Fixes
- `modules/web_based.py` 한글 주석 6곳 복원 (강물 온도 조회, 현재 시간 기록 등)
- 사용자 노출 문자 복원: `°C` 2곳, RSS 헤더 `월`/`일`, bullet `•`

### Refactoring / Tooling
- `.gitattributes` 에 `*.py text working-tree-encoding=UTF-8` 추가 — CP949 작업 트리에서 staging 시 UTF-8 변환 강제
- pre-commit `detect-mojibake` 로컬 훅 + `scripts/detect_mojibake.py` 신규
- 검출 패턴: `째[A-Za-z]`, `\?[가-힣]`, `\?\?[가-힣]`

### Test
- `tests/test_web_based.py::TestRssHandler::test_success` 에 `"04월 24일"`, `"•"` 존재 assert 추가

## 도입 추적 (참고)
- 도입 커밋: `53e8e7a chore: add .gitattributes to enforce LF line endings` (PR #42, 2026-04-24 18:34 KST, by h1ghg3n)
- 정황: `text=auto eol=lf` 추가 시 작성자 작업 트리의 CP949 인코딩이 정규화 과정에서 그대로 staging → UTF-8 컨텍스트에 mojibake로 박힘. 한 커밋에서 web_based.py 9곳이 동시에 깨짐.
- 사전 스캔 결과 web_based.py 외 영향받은 파일 없음.

## Test plan
- [x] ruff check / ruff format --check 통과
- [x] pytest 350 passed (회귀 방지 assert 포함)
- [x] detect_mojibake.py self-check + 가짜 입력에 대한 exit=1 검증
