### PR TITLE
Enable Telegram API retry on connection failure

### DIFF
--- a/bin/handlers.py
+++ b/bin/handlers.py
@@ -1,4 +1,5 @@
 import telebot
+import tenacity
 
 from modules.features_hub import BotFeaturesHub
 from resources import strings
@@ -51,9 +52,14 @@ def register_handlers(bot, hub, logger):
             except Exception:
                 logger.log_error(f"Handler {func.__name__} failed for message: {getattr(message, 'text', None)}")
                 try:
-                    bot.reply_to(message, strings.generic_error_msg)
-                except Exception:
-                    pass
+                    for attempt in tenacity.Retrying(
+                        stop=tenacity.stop_after_attempt(3),
+                        wait=tenacity.wait_exponential(multiplier=1, min=1, max=8),
+                    ):
+                        with attempt:
+                            bot.reply_to(message, strings.generic_error_msg)
+                except tenacity.RetryError:
+                    logger.log_error(f"Failed to send error message for {func.__name__} after retries")
 
         return wrapper
 

--- a/bin/main.py
+++ b/bin/main.py
@@ -21,6 +21,10 @@ BOT_INTERVAL = 3
 BOT_TIMEOUT = 30
 CLEANUP_INTERVAL = 600
 
+telebot.apihelper.RETRY_ON_ERROR = True
+telebot.apihelper.CONNECT_TIMEOUT = 10
+telebot.apihelper.READ_TIMEOUT = 30
+
 # Validate required environment variables
 config.validate()
 
@@ -34,7 +38,10 @@ hub = BotFeaturesHub(bot)
 logger = log.Logger()
 
 # Register commands and handlers
-register_commands(bot)
+try:
+    register_commands(bot)
+except Exception as e:
+    print(f"register_commands failed at startup: {e}", flush=True)
 register_handlers(bot, hub, logger)
 
 shutdown_event = threading.Event()

--- a/bin/main.py
+++ b/bin/main.py
@@ -21,7 +21,6 @@ BOT_INTERVAL = 3
 BOT_TIMEOUT = 30
 CLEANUP_INTERVAL = 600
 
-telebot.apihelper.RETRY_ON_ERROR = True
 telebot.apihelper.CONNECT_TIMEOUT = 10
 telebot.apihelper.READ_TIMEOUT = 30
 
@@ -38,10 +37,13 @@ hub = BotFeaturesHub(bot)
 logger = log.Logger()
 
 # Register commands and handlers
+telebot.apihelper.RETRY_ON_ERROR = False
 try:
     register_commands(bot)
 except Exception as e:
     print(f"register_commands failed at startup: {e}", flush=True)
+finally:
+    telebot.apihelper.RETRY_ON_ERROR = True
 register_handlers(bot, hub, logger)
 
 shutdown_event = threading.Event()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pydantic>=2.9,<3",
     "peewee>=3.17,<5",
     "telegramify-markdown>=1.0,<2",
+    "tenacity>=8.0,<10",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -67,7 +67,8 @@ class TestSafeHandlerErrorBoundary:
         msg = make_message("/ask test")
         handlers["ask"](msg)
 
-        logger.log_error.assert_called_once()
+        assert logger.log_error.call_count == 2
+        assert bot.reply_to.call_count == 3
 
     def test_safe_handler_not_applied_to_ping(self):
         hub = MagicMock()


### PR DESCRIPTION
## Summary
- `RETRY_ON_ERROR = True`로 Telegram API 호출 실패 시 자동 재시도 활성화
- `CONNECT_TIMEOUT = 10`, `READ_TIMEOUT = 30` 설정으로 연결 안정성 향상
- 시작 시 `register_commands()` 실패해도 봇이 크래시되지 않도록 try/except 추가
- `register_commands` 실행 중 retry를 일시 비활성화하여 시작 딜레이 개선
- `safe_handler` 에러 메시지 송신 실패 시 tenacity 지수 백오프로 최대 3회 재시도

## Changes
### Bug Fixes
- `bin/main.py`: Enable `telebot.apihelper.RETRY_ON_ERROR` and configure timeouts
- `bin/main.py`: Wrap `register_commands(bot)` in try/except to prevent startup crash
- `bin/main.py`: Temporarily disable `RETRY_ON_ERROR` during `register_commands` to avoid startup delay
- `bin/handlers.py`: Add tenacity exponential backoff retry to `safe_handler` error reply

### Dependencies
- `pyproject.toml`: Add `tenacity>=8.0,<10` runtime dependency

## Test plan
- [x] ruff check / format 통과
- [x] pytest 통과 (350 passed)
- [x] Jetson에서 로컬 실행 확인 (네트워크 에러 시 재시도 동작 확인)
- [x] 시작 딜레이 개선 확인
- [x] safe_handler retry 동작 확인 (Jetson 테스트)
