### PR TITLE
Add multi-feed slug and date support to /bfrss command

### DIFF
--- a/bin/handlers.py
+++ b/bin/handlers.py
@@ -1,3 +1,5 @@
+import re
+
 import telebot
 import tenacity
 
@@ -193,7 +195,22 @@ def register_handlers(bot, hub, logger):
     @bot.message_handler(commands=["bfrss"])
     @safe_handler
     def handle_bfrss(message):
-        hub.rss_handler(message)
+        m = re.match(r"^/bfrss(?:@\w+)?(?:[ \t]+(\S+))?(?:\n(\S+))?", message.text or "")
+        arg1 = m.group(1) if m else None
+        arg2 = m.group(2) if m else None
+        if arg1 is None:
+            slug = "hn"
+        elif re.fullmatch(r"-\w+", arg1):
+            slug = arg1.lstrip("-").lower()
+        else:
+            slug = ""
+        if arg2 is not None:
+            date = "20" + arg2 if re.fullmatch(r"\d{6}", arg2) else ""
+            if not date:
+                slug = ""
+        else:
+            date = ""
+        hub.rss_handler(message, slug, date)
 
     # Location
     @bot.message_handler(content_types=["location"])

--- a/modules/api_models.py
+++ b/modules/api_models.py
@@ -108,5 +108,5 @@ class RssfEntry(BaseModel):
 class RssfResponse(BaseModel):
     model_config = ConfigDict(extra="ignore")
     date: str = ""
-    hour: int = 0
+    hour: int | None = None
     entries: list[RssfEntry] = []

--- a/modules/features_hub.py
+++ b/modules/features_hub.py
@@ -202,8 +202,8 @@ class BotFeaturesHub:
                 self.bot.reply_to(message, plain_chunk)
 
     # RSS JSON request
-    def rss_handler(self, message):
-        text, parse_mode = self.web_manager.rss_handler(message)
+    def rss_handler(self, message, slug="hn", date=""):
+        text, parse_mode = self.web_manager.rss_handler(message, slug, date)
         self.bot.reply_to(message, text, parse_mode=parse_mode)
 
     # Clear chat

--- a/modules/web_based.py
+++ b/modules/web_based.py
@@ -142,12 +142,25 @@ class WebManager:
             return strings.suon_maintenance_status
         return self.suon_v2
 
-    def rss_handler(self, message):
+    def rss_handler(self, message, slug="hn", date=""):
+        if slug not in strings.bfrss_feed_names:
+            return strings.bfrss_unknown_feed_msg, None
         try:
-            res = requests.get(config.RSSF_URL, params={"token": config.RSSF_TOKEN}, timeout=10)
+            params = {"token": config.RSSF_TOKEN}
+            if date:
+                params["date"] = date
+            res = requests.get(f"{config.RSSF_URL}/feed/{slug}", params=params, timeout=10)
             data = RssfResponse.model_validate_json(res.text)
-            time_of_day = strings.bfrss_am if data.hour < 12 else strings.bfrss_pm
-            text = strings.bfrss_header_msg.format(month=data.date[4:6], day=data.date[6:], time_of_day=time_of_day)
+            feed_name = strings.bfrss_feed_names[slug]
+            if data.hour is not None:
+                time_of_day = strings.bfrss_am if data.hour < 12 else strings.bfrss_pm
+                text = strings.bfrss_header_msg.format(
+                    feed_name=feed_name, month=data.date[4:6], day=data.date[6:], time_of_day=time_of_day
+                )
+            else:
+                text = strings.bfrss_header_msg_no_time.format(
+                    feed_name=feed_name, month=data.date[4:6], day=data.date[6:]
+                )
             text += "\n".join(
                 f'• <a href="{html.escape(e.link, quote=True)}">{html.escape(e.title)}</a>' for e in data.entries
             )

--- a/resources/strings.py
+++ b/resources/strings.py
@@ -236,11 +236,20 @@ laftel_portal_btn = "포털로"
 laftel_help_msg = "/laftel 명령어로 라프텔 편성표, 랭킹, 검색 기능을 이용할 수 있습니다."
 
 # RSS feed translater message
-bfrss_help_msg = "번역된 rss를 보여줍니다. 주기는 오전 9시(딜레이 약 2분)에 갱신됩니다."
+bfrss_help_msg = (
+    "번역된 RSS를 보여줍니다.\n"
+    "사용법: /bfrss -(피드)\n"
+    "• 기본: hn (THE HACKER NEWS)\n"
+    "• -lob: Lobsters\n"
+    "• -reg: The Register"
+)
 bfrss_error_msg = "번역 서버에 연결할 수 없습니다."
+bfrss_unknown_feed_msg = "알 수 없는 피드입니다. 도움말을 다시 읽어주세요."
 bfrss_am = "오전"
 bfrss_pm = "오후"
-bfrss_header_msg = " HACKER NEWS ({month}월 {day}일 {time_of_day})\n\n"
+bfrss_header_msg = " {feed_name} ({month}월 {day}일 {time_of_day})\n\n"
+bfrss_header_msg_no_time = " {feed_name} ({month}월 {day}일)\n\n"
+bfrss_feed_names = {"hn": "THE HACKER NEWS", "lob": "LOBSTERS", "reg": "THE REGISTER"}
 
 # Resources
 

--- a/tests/test_web_based.py
+++ b/tests/test_web_based.py
@@ -273,34 +273,96 @@ class TestProvideSuonV2:
 
 
 class TestRssHandler:
-    @patch("modules.web_based.config.RSSF_URL", "http://test-server/hn")
+    _response_data = {
+        "date": "20260424",
+        "hour": 9,
+        "entries": [
+            {"title": "Test Article", "link": "https://example.com"},
+            {"title": "Article with <special> &chars", "link": "https://example.com/path?a=1&b=2"},
+        ],
+    }
+
+    @patch("modules.web_based.config.RSSF_URL", "http://test-server")
     @patch("modules.web_based.config.RSSF_TOKEN", "test_token")
     @patch("modules.web_based.requests.get")
     def test_success(self, mock_get):
         response = MagicMock()
-        response.text = json.dumps(
-            {
-                "date": "20260424",
-                "entries": [
-                    {"title": "Test Article", "link": "https://example.com"},
-                    {"title": "Article with <special> &chars", "link": "https://example.com/path?a=1&b=2"},
-                ],
-            }
-        )
+        response.text = json.dumps(self._response_data)
         mock_get.return_value = response
 
         with patch.object(WebManager, "__init__", lambda self: None):
             wm = WebManager()
             text, parse_mode = wm.rss_handler(MagicMock())
             assert parse_mode == "HTML"
-            assert "HACKER NEWS" in text
+            assert "THE HACKER NEWS" in text
             assert "Test Article" in text
             assert "&lt;special&gt;" in text
             assert "&amp;chars" in text
-            assert "04월 24일" in text
-            assert "•" in text
+            mock_get.assert_called_once_with(
+                "http://test-server/feed/hn",
+                params={"token": "test_token"},
+                timeout=10,
+            )
 
-    @patch("modules.web_based.config.RSSF_URL", "http://test-server/hn")
+    @patch("modules.web_based.config.RSSF_URL", "http://test-server")
+    @patch("modules.web_based.config.RSSF_TOKEN", "test_token")
+    @patch("modules.web_based.requests.get")
+    def test_slug(self, mock_get):
+        response = MagicMock()
+        response.text = json.dumps(self._response_data)
+        mock_get.return_value = response
+
+        with patch.object(WebManager, "__init__", lambda self: None):
+            wm = WebManager()
+            text, parse_mode = wm.rss_handler(MagicMock(), slug="lob")
+            assert parse_mode == "HTML"
+            assert "LOBSTERS" in text
+            mock_get.assert_called_once_with(
+                "http://test-server/feed/lob",
+                params={"token": "test_token"},
+                timeout=10,
+            )
+
+    @patch("modules.web_based.config.RSSF_URL", "http://test-server")
+    @patch("modules.web_based.config.RSSF_TOKEN", "test_token")
+    @patch("modules.web_based.requests.get")
+    def test_date_param(self, mock_get):
+        response = MagicMock()
+        response.text = json.dumps(self._response_data)
+        mock_get.return_value = response
+
+        with patch.object(WebManager, "__init__", lambda self: None):
+            wm = WebManager()
+            wm.rss_handler(MagicMock(), slug="lob", date="20260507")
+            mock_get.assert_called_once_with(
+                "http://test-server/feed/lob",
+                params={"token": "test_token", "date": "20260507"},
+                timeout=10,
+            )
+
+    @patch("modules.web_based.config.RSSF_URL", "http://test-server")
+    @patch("modules.web_based.config.RSSF_TOKEN", "test_token")
+    @patch("modules.web_based.requests.get")
+    def test_hour_none(self, mock_get):
+        response = MagicMock()
+        response.text = json.dumps({**self._response_data, "hour": None})
+        mock_get.return_value = response
+
+        with patch.object(WebManager, "__init__", lambda self: None):
+            wm = WebManager()
+            text, parse_mode = wm.rss_handler(MagicMock())
+            assert parse_mode == "HTML"
+            assert "오전" not in text
+            assert "오후" not in text
+
+    def test_unknown_slug(self):
+        with patch.object(WebManager, "__init__", lambda self: None):
+            wm = WebManager()
+            text, parse_mode = wm.rss_handler(MagicMock(), slug="xyz")
+            assert text == strings.bfrss_unknown_feed_msg
+            assert parse_mode is None
+
+    @patch("modules.web_based.config.RSSF_URL", "http://test-server")
     @patch("modules.web_based.config.RSSF_TOKEN", "test_token")
     @patch("modules.web_based.requests.get")
     def test_server_failure(self, mock_get):


### PR DESCRIPTION
## Summary
- `/bfrss` 명령어에 다중 피드(hn/lob/reg) 슬러그 지원 추가
- 날짜 파라미터(`YYMMDD`, Shift+Enter 구분) 지원 추가
- `RssfResponse.hour` nullable 처리 (hour 없을 때 시간 표기 생략)
- 위 변경에 대응하는 테스트 케이스 추가

## Changes

### New Features
- `/bfrss -lob`, `/bfrss -reg` 슬러그 옵션 추가 (기본값: `hn`)
- 날짜 파라미터: `/bfrss -lob` + Shift+Enter + `YYMMDD` 형식 지원
- 슬러그 대소문자 무관 처리 (`-LOB` → `lob`)
- `GET /feed/{slug}` 엔드포인트 호출로 변경
- 알 수 없는 슬러그 입력 시 `bfrss_unknown_feed_msg` 반환

### Bug Fixes
- `RssfResponse.hour` 타입 `int` → `int | None`, `None` 시 `bfrss_header_msg_no_time` 사용

### Tests
- `TestRssHandler` 케이스 추가: slug, date param, hour None, unknown slug, 기존 success 케이스 URL 검증 강화

## Test plan
- [x] `pytest -v` 통과
- [x] ruff check / format 통과