### PR TITLE
Add RSSF secrets to documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,8 @@ development → PR → master (merge) → GitHub Release 생성
 | `SEOUL_HANGANG_WATER_TOKEN` | 서울 열린데이터 토큰 |
 | `GEMINI_API_KEY` | Google Gemini API 키 |
 | `ADMIN_USER_ID` | 관리자 텔레그램 사용자 ID |
+| `RSSF_TOKEN` | RSS 번역 서버 인증 토큰 |
+| `RSSF_URL` | RSS 번역 서버 URL |
 
 ## 커밋 컨벤션
 


### PR DESCRIPTION
## Summary
- RSS 피더 기능(#42)에서 도입된 `RSSF_TOKEN`, `RSSF_URL` GitHub Secrets가 `CLAUDE.md` 문서에 누락되어 추가

## Changes
### Documentation
- `CLAUDE.md`의 "필요한 GitHub Secrets" 표에 `RSSF_TOKEN`(RSS 번역 서버 인증 토큰), `RSSF_URL`(RSS 번역 서버 URL) 항목 추가

## Test plan
- [x] 문서 변경만 포함 (코드 변경 없음)
- [x] pre-commit 통과 (gitleaks, mojibake 검사)