### PR TITLE
Stop CD from pushing version bump to protected master

### DIFF
--- a/.claude/rules/deployment.md
+++ b/.claude/rules/deployment.md
@@ -16,10 +16,12 @@
                              GitHub Release 생성 (vX.Y.Z)
                                       ↓
                              CD 자동 실행:
-                               1. pyproject.toml 버전 자동 업데이트
+                               1. Release 태그 버전을 빌드 컨텍스트 pyproject.toml에 반영 (master push 없음)
                                2. Docker 빌드 (amd64 + arm64) → GHCR push
                                3. 배포 서버에 SSH 배포
 ```
+
+> master는 보호 브랜치라 CD가 버전 bump 커밋을 직접 push하지 않는다. master의 `pyproject.toml` 버전을 최신으로 유지하려면 release PR에서 직접 bump한다.
 
 ## Release 생성
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,7 +8,7 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       packages: write
     steps:
       - uses: actions/checkout@v6
@@ -18,14 +18,6 @@ jobs:
         run: |
           VERSION=${GITHUB_REF_NAME#v}
           sed -i "s/^version = .*/version = \"$VERSION\"/" pyproject.toml
-      - name: Commit version bump
-        run: |
-          VERSION=${GITHUB_REF_NAME#v}
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml
-          git diff --cached --quiet || git commit -m "chore: bump version to $VERSION"
-          git push origin HEAD:master
       - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,15 +79,17 @@ GitHub Actions (`cd.yml`) — GitHub Release 생성 시 실행.
 development → PR → master (merge) → GitHub Release 생성
                                         ↓
                                CD workflow:
-                                 1. pyproject.toml 버전 자동 업데이트
+                                 1. Release 태그에서 추출한 버전을 빌드 컨텍스트의 pyproject.toml에 반영 (master에 commit하지 않음)
                                  2. Docker 이미지 빌드 (ARM64) → GHCR push (버전 태그 + latest)
                                  3. Tailscale VPN 연결
                                  4. SSH로 배포 서버 접속 → .env 갱신 + docker compose pull + up -d
 ```
 
+> master는 보호 브랜치라 CD가 직접 push할 수 없으므로, 버전은 빌드 컨텍스트에서만 갱신되어 이미지에 반영된다. master git의 `pyproject.toml` 버전을 최신으로 유지하려면 release PR(development → master)에서 직접 bump한다.
+
 | Job | 내용 |
 |-----|------|
-| `build-and-push` | Release 태그에서 버전 추출 → pyproject.toml 업데이트 → QEMU + Buildx로 ARM64 이미지 빌드, GHCR에 push |
+| `build-and-push` | Release 태그에서 버전 추출 → 빌드 컨텍스트 pyproject.toml에 반영 → QEMU + Buildx로 ARM64 이미지 빌드, GHCR에 push |
 | `deploy` | Tailscale VPN 연결 → SSH로 배포 서버에 .env 배포 + 컨테이너 재시작 |
 
 워크플로우 파일: `.github/workflows/cd.yml`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sungsimdangbot"
-version = "1.6.0"
+version = "1.7.0"
 description = "Telegram bot with various utility features"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## Summary
- master 브랜치 보호(PR 필수 + status check 필수)로 CD의 `git push origin HEAD:master`가 거부되어 v1.7.0 배포가 실패함
- 버전 커밋을 master에 남기지 않아도 이미지 버전은 release 태그 기반으로 정확하므로 push 단계를 제거

## Changes
### Bug Fixes
- `cd.yml`: "Commit version bump" 단계 제거 (master 직접 push 제거)
- 버전은 `sed`로 빌드 컨텍스트의 pyproject.toml에만 반영 → 이미지 태그/메타데이터는 그대로 정확

### Refactoring
- `cd.yml`: `contents` 권한을 write→read로 축소 (push 제거에 따른 least-privilege)

### Chore
- `pyproject.toml`: 1.6.0 → 1.7.0 직접 bump

### Docs
- CD 동작 변경(master push 없음, release PR에서 버전 bump)을 CLAUDE.md / deployment 규칙에 반영

## Test plan
- [x] pre-commit 통과 (gitleaks, mojibake)
- [x] cd.yml 구조 확인 (sed 단계 유지, push 단계 제거)
- [ ] master 반영 후 v1.7.0 release 재생성으로 CD 정상 동작 검증 예정