### PR TITLE
Upgrade base image to Python 3.14 and add pip dependency cooldown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.14"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -19,6 +19,8 @@ jobs:
           cache: pip
       - name: Install dependencies
         run: pip install -e ".[dev]"
+        env:
+          PIP_UPLOADED_PRIOR_TO: P3D
       - name: Lint
         run: ruff check .
       - name: Format check
@@ -26,7 +28,7 @@ jobs:
       - name: Test
         run: pytest -v --cov --cov-report=term-missing --cov-report=xml
       - name: Upload coverage
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.14'
         uses: actions/upload-artifact@v7
         with:
           name: coverage-report

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-FROM python:3.12-slim
+FROM python:3.14-slim
 
 WORKDIR /app
+
+ENV PYTHONPATH=/app \
+    PIP_UPLOADED_PRIOR_TO=P3D
 
 # 의존성 레이어 (pyproject.toml 변경 시에만 재빌드)
 COPY pyproject.toml .
@@ -14,7 +17,6 @@ COPY . .
 RUN pip install --no-cache-dir --no-deps . && \
     useradd -m -u 1000 bot && \
     mkdir -p /app/data /app/log && chown -R bot:bot /app/data /app/log
-ENV PYTHONPATH=/app
 # NOTE: non-root 전환. 기존 root로 생성된 data/ 볼륨은 호스트에서
 # chown -R 1000:1000 ./data 실행 필요 (CD 워크플로우에서 자동 처리)
 USER bot


### PR DESCRIPTION
## Summary
- 베이스 이미지를 python:3.12-slim → python:3.14-slim으로 업그레이드
- pip dependency cooldown(`PIP_UPLOADED_PRIOR_TO=P3D`) 적용으로 공급망 공격 대응
- CI 매트릭스를 3.12 → 3.14로 통일

## Changes
### Security
- `ENV PIP_UPLOADED_PRIOR_TO=P3D` 추가 — 출시 3일 미만 패키지 설치 차단 (pip 26.1+ 네이티브 기능)

### Infrastructure
- Dockerfile 베이스 이미지: `python:3.12-slim` → `python:3.14-slim` (pip 26.1.1 번들)
- `ENV` 선언을 `WORKDIR` 직후로 이동해 의존성 설치 레이어 전체에 쿨다운 적용
- CI 매트릭스: `["3.10", "3.12"]` → `["3.10", "3.14"]`
- coverage 업로드 조건: `3.12` → `3.14`

## Test plan
- [x] Python 3.14 로컬 venv에서 pytest 361개 통과
- [x] `docker build` 로컬 빌드 성공 확인 (python:3.14-slim, pip 26.1.1 번들 확인)
- [x] ruff check / format 통과