### PR TITLE
Reduce duplicate mojibake detections

### DIFF
--- a/scripts/detect_mojibake.py
+++ b/scripts/detect_mojibake.py
@@ -9,8 +9,8 @@ import sys
 # - "?" 직후 한글: CP949 바이트가 UTF-8로 디코딩될 때 흔한 패턴
 PATTERNS = [
     (re.compile(r"째[A-Za-z]"), "단위 깨짐 (°C/°F가 CP949로 깨진 형태)"),
-    (re.compile(r"\?[가-힣]"), "물음표 뒤 한글 (CP949 mojibake)"),
     (re.compile(r"\?\?[가-힣]"), "물음표 두 개 뒤 한글 (CP949 mojibake)"),
+    (re.compile(r"\?[가-힣]"), "물음표 뒤 한글 (CP949 mojibake)"),
 ]
 
 
@@ -28,6 +28,7 @@ def main(paths: list[str]) -> int:
                 if pattern.search(line):
                     print(f"{path}:{lineno}: {label}: {line.rstrip()}")
                     failed = True
+                    break
 
     if failed:
         print("\nmojibake detected. 파일이 CP949/EUC-KR로 저장된 채 커밋되었을 수 있습니다.")


### PR DESCRIPTION
## Summary
- mojibake 감지 훅에서 같은 줄의 중복 감지 출력을 줄였습니다.
- 더 구체적인 `??한글` 패턴을 `?한글` 패턴보다 먼저 검사하도록 순서를 조정했습니다.
- 한 줄에서 패턴이 감지되면 추가 검사를 중단하도록 했습니다.

## Changes
### Chores
- `\?\?[가-힣]` 패턴을 `\?[가-힣]` 패턴보다 먼저 검사
- 한 줄에서 첫 mojibake 패턴 감지 후 `break` 처리

## Related review
- https://github.com/kry-p/SungsimdangBot/pull/53#discussion_r3282174961

## Required GitHub Secrets (new)
- 없음.

## Test plan
- [x] `??한글` 입력에서 감지 라인이 1개만 출력되는지 확인
- [x] `python -m ruff check scripts/detect_mojibake.py`
- [x] `python -m ruff format --check scripts/detect_mojibake.py`
- [x] `pre-commit run detect-mojibake --all-files`
- [x] `git diff --check`