### PR TITLE
Bump version to 1.8.0

### DIFF
--- a/.claude/rules/deployment.md
+++ b/.claude/rules/deployment.md
@@ -5,30 +5,53 @@
 - `master` — production, GitHub Release 생성 시 배포
 - `development` — 통합 브랜치, CI 실행
 - `feature/*`, `fix/*`, `refactor/*` 등 — 작업 브랜치
+- `release/vX.Y.Z` — 버전 bump 전용 브랜치
 
 ## 배포 흐름
 
 ```
 작업 브랜치 → PR → development (merge)
                       ↓
-               development → PR → master (merge)
-                                      ↓
-                             GitHub Release 생성 (vX.Y.Z)
-                                      ↓
-                             CD 자동 실행:
-                               1. Release 태그 버전을 빌드 컨텍스트 pyproject.toml에 반영 (master push 없음)
-                               2. Docker 빌드 (amd64 + arm64) → GHCR push
-                               3. 배포 서버에 SSH 배포
+              release/vX.Y.Z 브랜치 생성 (from development)
+                      │
+                      ├─ pyproject.toml 버전 bump 커밋
+                      │
+                      ├─→ PR → development (merge) ← 버전이 development에 반영
+                      │
+                      └─→ PR → master (merge)
+                                    ↓
+                           GitHub Release 생성 (vX.Y.Z)
+                                    ↓
+                           CD 자동 실행:
+                             1. Release 태그 버전을 빌드 컨텍스트 pyproject.toml에 반영 (master push 없음)
+                             2. Docker 빌드 (ARM64) → GHCR push
+                             3. 배포 서버에 SSH 배포
 ```
 
-> master는 보호 브랜치라 CD가 버전 bump 커밋을 직접 push하지 않는다. master의 `pyproject.toml` 버전을 최신으로 유지하려면 release PR에서 직접 bump한다.
+> release 브랜치는 development와 master 양쪽에 머지해 버전이 두 브랜치에 모두 반영되도록 한다.
+
+## Release 절차
+
+1. `development`에서 `release/vX.Y.Z` 브랜치 생성
+2. `pyproject.toml` 버전 bump 커밋 (`chore: bump version to X.Y.Z`)
+3. PR `release/vX.Y.Z → development` 생성 및 머지
+4. PR `release/vX.Y.Z → master` 생성 및 머지
+5. `gh release create vX.Y.Z --target master --generate-notes --title "vX.Y.Z"`
+
+## 버전 관리 (Semver)
+
+| 변경 | 버전 |
+|------|------|
+| 호환성 깨지는 변경 | Major (X) |
+| 새 기능 추가 | Minor (Y) |
+| 버그 수정, 리팩터링 | Patch (Z) |
 
 ## Release 생성
 
 - 태그 형식: `vX.Y.Z` (semver)
 - **target은 반드시 `master`** — 다른 브랜치에서 Release를 생성하지 않음
-- 릴리즈 노트에 주요 변경사항 기재
-- 예: `gh release create vX.Y.Z --target master --title "vX.Y.Z"`
+- 릴리즈 노트: `--generate-notes`로 자동 생성
+- 예: `gh release create vX.Y.Z --target master --generate-notes --title "vX.Y.Z"`
 
 ## CI/CD 트리거 조건
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sungsimdangbot"
-version = "1.7.0"
+version = "1.8.0"
 description = "Telegram bot with various utility features"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## Summary
- \`pyproject.toml\` 1.7.0 → 1.8.0 버전 bump
- \`deployment.md\` 릴리즈 절차 정비: \`release/vX.Y.Z\` 브랜치 기반 워크플로우 문서화

## Changes
### Chore
- pyproject.toml 버전 bump
- \`.claude/rules/deployment.md\`: release 브랜치 전략, Semver 기준, 릴리즈 절차 추가

## Test plan
- [x] 코드 변경 없음 — 버전 및 문서만 수정