### PR TITLE
Fix OpenAI provider always disabled in production

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -80,6 +80,7 @@ jobs:
             SEOUL_HANGANG_WATER_TOKEN=${{ secrets.SEOUL_HANGANG_WATER_TOKEN }}
             GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }}
             OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
+            OPENAI_BASE_URL=${{ secrets.OPENAI_BASE_URL }}
             ADMIN_USER_ID=${{ secrets.ADMIN_USER_ID }}
             RSSF_TOKEN=${{ secrets.RSSF_TOKEN }}
             RSSF_URL=${{ secrets.RSSF_URL }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -79,6 +79,7 @@ jobs:
             WEATHER_TOKEN=${{ secrets.WEATHER_TOKEN }}
             SEOUL_HANGANG_WATER_TOKEN=${{ secrets.SEOUL_HANGANG_WATER_TOKEN }}
             GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }}
+            OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
             ADMIN_USER_ID=${{ secrets.ADMIN_USER_ID }}
             RSSF_TOKEN=${{ secrets.RSSF_TOKEN }}
             RSSF_URL=${{ secrets.RSSF_URL }}

--- a/config/config.py
+++ b/config/config.py
@@ -34,7 +34,7 @@ GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
 
 # OpenAI API
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
-OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
+OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1"
 
 # AI 공통 (AI_* 우선, 없으면 GEMINI_* fallback)
 AI_SESSION_TIMEOUT = _int_env_with_fallback("AI_SESSION_TIMEOUT", "GEMINI_SESSION_TIMEOUT", 3600)

--- a/tests/test_ai_chat.py
+++ b/tests/test_ai_chat.py
@@ -204,7 +204,7 @@ class TestProviderManagement:
             _, kwargs = mock_gemini.call_args
             assert kwargs.get("search_enabled") is True
 
-    def test_available_providers(self):
+    def test_available_providers_excludes_openai_when_key_empty(self):
         m = make_manager()
         with patch("modules.ai.chat.config") as mc:
             mc.GEMINI_API_KEY = "g-key"
@@ -212,6 +212,15 @@ class TestProviderManagement:
             providers = m.available_providers()
         assert "gemini" in providers
         assert "openai" not in providers
+
+    def test_available_providers_includes_openai_when_key_set(self):
+        m = make_manager()
+        with patch("modules.ai.chat.config") as mc:
+            mc.GEMINI_API_KEY = ""
+            mc.OPENAI_API_KEY = "sk-key"
+            providers = m.available_providers()
+        assert "openai" in providers
+        assert "gemini" not in providers
 
 
 class TestDelegation:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,4 @@
+import importlib
 from unittest.mock import patch
 
 from config.config import _int_env
@@ -23,3 +24,26 @@ class TestIntEnv:
     @patch.dict("os.environ", {"TEST_KEY": "-5"})
     def test_negative_value(self):
         assert _int_env("TEST_KEY", 0) == -5
+
+
+class TestOpenAIBaseURL:
+    def _reload(self):
+        import config.config as c
+
+        importlib.reload(c)
+        return c
+
+    def test_custom_url(self):
+        with patch.dict("os.environ", {"OPENAI_BASE_URL": "https://custom.api.com/v1"}):
+            c = self._reload()
+            assert c.OPENAI_BASE_URL == "https://custom.api.com/v1"
+
+    def test_empty_string_falls_back_to_default(self):
+        with patch.dict("os.environ", {"OPENAI_BASE_URL": ""}):
+            c = self._reload()
+            assert c.OPENAI_BASE_URL == "https://api.openai.com/v1"
+
+    def test_missing_key_falls_back_to_default(self):
+        with patch.dict("os.environ", {}, clear=True):
+            c = self._reload()
+            assert c.OPENAI_BASE_URL == "https://api.openai.com/v1"


### PR DESCRIPTION
## Summary
- CD 배포 스크립트의 `.env` 생성 시 `OPENAI_API_KEY`가 누락되어 프로덕션에서 OpenAI 프로바이더가 항상 비활성화되던 문제 수정
- `OPENAI_BASE_URL`도 `.env`에 추가하고, Secret 미등록 시 빈 문자열이 주입되어 기본값이 무시되는 문제를 `config.py`에서 방어
- 두 수정에 대한 테스트 케이스 보완

## Changes
### Bug Fixes
- `cd.yml`: 배포 시 생성하는 `.env`에 `OPENAI_API_KEY`, `OPENAI_BASE_URL` 추가
- `config/config.py`: `OPENAI_BASE_URL`을 `os.getenv(key, default)` 대신 `or` 패턴으로 변경 — 빈 문자열 주입 시에도 기본 엔드포인트(`https://api.openai.com/v1`) 사용

### Tests
- `test_config.py`: `OPENAI_BASE_URL`이 빈 문자열/미설정/커스텀 URL일 때 동작 검증
- `test_ai_chat.py`: `available_providers()`가 `OPENAI_API_KEY` 설정 시 `openai`를 포함하는 케이스 추가 (기존엔 제외 케이스만 있었음)

## Required GitHub Secrets (new)
- `OPENAI_API_KEY`: OpenAI API 키
- `OPENAI_BASE_URL`: OpenAI 호환 엔드포인트 URL (선택 — 미등록 시 `https://api.openai.com/v1` 사용)

## Test plan
- [x] pytest 443개 통과
- [x] ruff check / format 통과