### PR TITLE
Release v1.8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sungsimdangbot"
-version = "1.8.0"
+version = "1.8.1"
 description = "Telegram bot with various utility features"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## Summary
- 프로덕션 환경에서 OpenAI 프로바이더가 항상 비활성화되던 버그 수정
- 관련 테스트 케이스 보완

## Changes
### Bug Fixes
- `cd.yml`: 배포 시 생성하는 `.env`에 `OPENAI_API_KEY`, `OPENAI_BASE_URL` 추가 — 누락으로 인해 `config.OPENAI_API_KEY`가 항상 빈 문자열이 되어 OpenAI 프로바이더가 비활성화되던 문제 수정
- `config/config.py`: `OPENAI_BASE_URL`을 `or` 패턴으로 변경 — Secret 미등록 시 빈 문자열이 주입되어도 기본 엔드포인트 사용

### Tests
- `test_config.py`: `OPENAI_BASE_URL` 빈 문자열/미설정/커스텀 URL 동작 검증
- `test_ai_chat.py`: `available_providers()`에 `OPENAI_API_KEY` 설정 시 openai 포함 케이스 추가

### Chore
- `pyproject.toml`: version `1.8.0` → `1.8.1`

## Required GitHub Secrets (new)
- `OPENAI_API_KEY`: OpenAI API 키
- `OPENAI_BASE_URL`: OpenAI 호환 엔드포인트 URL (선택)

## Test plan
- [x] pytest 443개 통과
- [x] ruff check / format 통과