### PR TITLE
Derive version from git tags to remove cosmetic version-bump PRs

### DIFF
--- a/.claude/rules/deployment.md
+++ b/.claude/rules/deployment.md
@@ -5,38 +5,28 @@
 - `master` — production, GitHub Release 생성 시 배포
 - `development` — 통합 브랜치, CI 실행
 - `feature/*`, `fix/*`, `refactor/*` 등 — 작업 브랜치
-- `release/vX.Y.Z` — 버전 bump 전용 브랜치
 
 ## 배포 흐름
 
 ```
-작업 브랜치 → PR → development (merge)
+작업 브랜치 → PR → development (merge, 리뷰)
                       ↓
-              release/vX.Y.Z 브랜치 생성 (from development)
-                      │
-                      ├─ pyproject.toml 버전 bump 커밋
-                      │
-                      ├─→ PR → development (merge) ← 버전이 development에 반영
-                      │
-                      └─→ PR → master (merge)
-                                    ↓
-                           GitHub Release 생성 (vX.Y.Z)
-                                    ↓
-                           CD 자동 실행:
-                             1. Release 태그 버전을 빌드 컨텍스트 pyproject.toml에 반영 (master push 없음)
-                             2. Docker 빌드 (ARM64) → GHCR push
-                             3. 배포 서버에 SSH 배포
+              PR → master (merge, 리뷰)
+                      ↓
+             GitHub Release 생성 (vX.Y.Z, --target master)
+                      ↓
+             CD 자동 실행:
+               1. Release 태그에서 버전 추출 → VERSION build-arg로 전달
+               2. Docker 빌드 (setuptools-scm이 build-arg 버전 반영, ARM64) → GHCR push
+               3. 배포 서버에 SSH 배포
 ```
 
-> release 브랜치는 development와 master 양쪽에 머지해 버전이 두 브랜치에 모두 반영되도록 한다.
+> 버전은 git 태그가 단일 진실 공급원이다. `pyproject.toml`에는 정적 버전 값이 없으며(`dynamic = ["version"]` + setuptools-scm), 별도 버전 bump 커밋/브랜치가 필요 없다.
 
 ## Release 절차
 
-1. `development`에서 `release/vX.Y.Z` 브랜치 생성
-2. `pyproject.toml` 버전 bump 커밋 (`chore: bump version to X.Y.Z`)
-3. PR `release/vX.Y.Z → development` 생성 및 머지
-4. PR `release/vX.Y.Z → master` 생성 및 머지
-5. `gh release create vX.Y.Z --target master --generate-notes --title "vX.Y.Z"`
+1. PR `development → master` 생성, 리뷰 후 머지
+2. `gh release create vX.Y.Z --target master --generate-notes --title "vX.Y.Z"`
 
 ## 버전 관리 (Semver)
 

--- a/.claude/rules/docker-local.md
+++ b/.claude/rules/docker-local.md
@@ -26,3 +26,4 @@ docker rm -f sungsimdangbot
 - 기존 컨테이너가 있으면 `docker rm -f sungsimdangbot`으로 정리 후 실행
 - `.env` 파일이 프로젝트 루트에 있어야 함
 - `data/` 디렉토리는 SQLite DB 영속화를 위해 볼륨 마운트
+- 로컬 빌드는 버전이 기본값 `0.0.0`으로 설정된다. 특정 버전이 필요하면 `--build-arg VERSION=X.Y.Z`를 지정 (버전은 정상적으로는 릴리즈 태그에서 주입됨)

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,10 +14,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: master
-      - name: Update version in pyproject.toml
-        run: |
-          VERSION=${GITHUB_REF_NAME#v}
-          sed -i "s/^version = .*/version = \"$VERSION\"/" pyproject.toml
+      - name: Resolve version
+        id: ver
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v4
@@ -40,6 +39,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.ver.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,17 +79,17 @@ GitHub Actions (`cd.yml`) — GitHub Release 생성 시 실행.
 development → PR → master (merge) → GitHub Release 생성
                                         ↓
                                CD workflow:
-                                 1. Release 태그에서 추출한 버전을 빌드 컨텍스트의 pyproject.toml에 반영 (master에 commit하지 않음)
+                                 1. Release 태그에서 추출한 버전을 VERSION build-arg로 전달 (setuptools-scm이 이미지 빌드에 반영)
                                  2. Docker 이미지 빌드 (ARM64) → GHCR push (버전 태그 + latest)
                                  3. Tailscale VPN 연결
                                  4. SSH로 배포 서버 접속 → .env 갱신 + docker compose pull + up -d
 ```
 
-> master는 보호 브랜치라 CD가 직접 push할 수 없으므로, 버전은 빌드 컨텍스트에서만 갱신되어 이미지에 반영된다. master git의 `pyproject.toml` 버전을 최신으로 유지하려면 release PR(development → master)에서 직접 bump한다.
+> 버전은 git 태그가 단일 진실 공급원이다. `pyproject.toml`은 `dynamic = ["version"]` + setuptools-scm을 사용하므로 정적 버전 값이 없고, CD는 태그 버전을 `VERSION` build-arg로 빌드에 주입한다. 별도 버전 bump 커밋/브랜치는 필요 없다.
 
 | Job | 내용 |
 |-----|------|
-| `build-and-push` | Release 태그에서 버전 추출 → 빌드 컨텍스트 pyproject.toml에 반영 → QEMU + Buildx로 ARM64 이미지 빌드, GHCR에 push |
+| `build-and-push` | Release 태그에서 버전 추출 → `VERSION` build-arg로 전달 → QEMU + Buildx로 ARM64 이미지 빌드, GHCR에 push |
 | `deploy` | Tailscale VPN 연결 → SSH로 배포 서버에 .env 배포 + 컨테이너 재시작 |
 
 워크플로우 파일: `.github/workflows/cd.yml`

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,19 +6,19 @@ ENV PYTHONPATH=/app \
     PIP_UPLOADED_PRIOR_TO=P3D
 
 # 버전 주입 (.dockerignore가 .git을 제외하므로 setuptools-scm에 PRETEND_VERSION 전달)
+# 빌드 전용 변수 — 런타임 이미지에 누출되지 않도록 ENV 대신 각 RUN에 인라인 적용
 ARG VERSION=0.0.0
-ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
 
 # 의존성 레이어 (pyproject.toml 변경 시에만 재빌드)
 COPY pyproject.toml .
 RUN mkdir -p config modules resources bin && \
     touch config/__init__.py modules/__init__.py resources/__init__.py bin/__init__.py && \
-    pip install --no-cache-dir . && \
+    SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION} pip install --no-cache-dir . && \
     rm -rf config modules resources bin
 
 # 소스 + 패키지 설치 레이어
 COPY . .
-RUN pip install --no-cache-dir --no-deps . && \
+RUN SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION} pip install --no-cache-dir --no-deps . && \
     useradd -m -u 1000 bot && \
     mkdir -p /app/data /app/log && chown -R bot:bot /app/data /app/log
 # NOTE: non-root 전환. 기존 root로 생성된 data/ 볼륨은 호스트에서

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ WORKDIR /app
 ENV PYTHONPATH=/app \
     PIP_UPLOADED_PRIOR_TO=P3D
 
+# 버전 주입 (.dockerignore가 .git을 제외하므로 setuptools-scm에 PRETEND_VERSION 전달)
+ARG VERSION=0.0.0
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
+
 # 의존성 레이어 (pyproject.toml 변경 시에만 재빌드)
 COPY pyproject.toml .
 RUN mkdir -p config modules resources bin && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,12 @@
+[build-system]
+requires = ["setuptools>=64", "setuptools-scm>=8"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "sungsimdangbot"
-version = "1.8.1"
 description = "Telegram bot with various utility features"
 requires-python = ">=3.10"
+dynamic = ["version"]
 dependencies = [
     "pyTelegramBotAPI>=4.14,<5",
     "requests>=2.28,<3",
@@ -22,6 +26,9 @@ dev = [
     "pytest-cov>=4.0",
     "pre-commit>=3.0",
 ]
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
 
 [tool.setuptools.packages.find]
 include = ["config*", "modules*", "resources*"]


### PR DESCRIPTION
## Summary
- 릴리즈마다 필요하던 cosmetic 버전 bump PR을 제거하고, git 태그를 버전의 단일 진실 공급원으로 전환
- `pyproject.toml`을 `dynamic = ["version"]` + setuptools-scm으로 변경, CD는 태그 버전을 `VERSION` build-arg로 주입
- master 보호·`development → master` 리뷰 게이트는 그대로 유지

## Changes
### Build / Release
- `pyproject.toml`: `[build-system]`(setuptools + setuptools-scm) 추가, 정적 `version` 제거 → `dynamic`, `fallback_version = "0.0.0"`
- `Dockerfile`: `ARG VERSION=0.0.0`로 받아 각 `pip install` RUN에 `SETUPTOOLS_SCM_PRETEND_VERSION` 인라인 적용 (런타임 이미지 누출 방지)
- `.github/workflows/cd.yml`: pyproject sed 스텝 제거, 릴리즈 태그 버전 추출 후 `VERSION` build-arg로 전달

### Docs
- `deployment.md` / `CLAUDE.md` / `docker-local.md`: release/* 브랜치·버전 bump 제거, 태그 기반 릴리즈 절차로 갱신

## Test plan
- [x] `pip install -e ".[dev]"` 버전 파생 확인
- [x] docker 빌드 검증 (build-arg 미지정 → `0.0.0`, 지정 → `9.9.9`, 런타임 env 누출 없음)
- [x] cd.yml YAML 문법 검증
- [x] ruff check / format / pytest 443개 통과