### PR TITLE
Prevent calculator resource exhaustion

### DIFF
--- a/modules/calculator.py
+++ b/modules/calculator.py
@@ -2,8 +2,28 @@ import math
 import re
 
 
+class CalculationLimitError(Exception):
+    pass
+
+
 class Calculator:
-    def __init__(self):
+    CALC_LIMIT_ERROR = "calculation limit error"
+    MAX_EXPRESSION_LENGTH = 2000
+    MAX_NUMBER_DIGITS = 1000
+    MAX_RESULT_DIGITS = 1000
+    MAX_TOKENS = 200
+
+    def __init__(
+        self,
+        max_expression_length=MAX_EXPRESSION_LENGTH,
+        max_number_digits=MAX_NUMBER_DIGITS,
+        max_result_digits=MAX_RESULT_DIGITS,
+        max_tokens=MAX_TOKENS,
+    ):
+        self.max_expression_length = max_expression_length
+        self.max_number_digits = max_number_digits
+        self.max_result_digits = max_result_digits
+        self.max_tokens = max_tokens
         self.library = {
             "operator": ["+", "-", "*", "/", "^", "(", ")"],
             "constant": ["pi", "e"],
@@ -25,6 +45,8 @@ class Calculator:
     # 계산 작업
     def operation(self, expression):
         try:
+            if len(expression) > self.max_expression_length:
+                raise CalculationLimitError
             check = self.wrong_syntax_checker(expression)
             if check == "syntax error":
                 return "syntax error"
@@ -37,6 +59,8 @@ class Calculator:
                 return result
             else:
                 return round(result, 4)
+        except CalculationLimitError:
+            return self.CALC_LIMIT_ERROR
         except (TypeError, UnboundLocalError, IndexError, SyntaxError, ValueError, OverflowError):
             return "syntax error"
         except ZeroDivisionError:
@@ -85,6 +109,11 @@ class Calculator:
 
         if "".join(tokens) != text:
             raise SyntaxError
+        if len(tokens) > self.max_tokens:
+            raise CalculationLimitError
+        for tok in tokens:
+            if re.fullmatch(r"\d+\.?\d*", tok) and self._numeric_token_digits(tok) > self.max_number_digits:
+                raise CalculationLimitError
 
         # 값 토큰: 숫자, 상수, 닫는 괄호
         def is_value(tok):
@@ -111,6 +140,8 @@ class Calculator:
                 result.extend(["-1", "*"])
             else:
                 result.append(tok)
+        if len(result) > self.max_tokens:
+            raise CalculationLimitError
 
         # 괄호 균형 검증
         depth = 0
@@ -125,6 +156,11 @@ class Calculator:
             raise SyntaxError
 
         return list(map(self.string_to_number, result))
+
+    @staticmethod
+    def _numeric_token_digits(token):
+        digits = token.replace(".", "").lstrip("0")
+        return max(len(digits), 1)
 
     # String 형태의 숫자를 정수와 실수로 변환
     @staticmethod
@@ -192,7 +228,7 @@ class Calculator:
 
         for i in postfix_notation:
             if isinstance(i, (int, float)) or i in self.library["constant"]:
-                stack.append(i)
+                stack.append(self._validate_number(i))
 
             # 스택에서 차례로 pop 한 뒤 연산
             # 0이면 error 를 반환하고 종료
@@ -212,12 +248,52 @@ class Calculator:
                     elif i == "/":
                         temp = num2 / num1
                     elif i == "^":
+                        self._validate_power_operands(num2, num1)
                         temp = pow(num2, num1)
                 # 함수
                 elif i in self.library["function"]:
                     num = stack.pop()
                     temp = self.function[i](num)
 
-                stack.append(temp)
+                stack.append(self._validate_number(temp))
 
         return stack[-1]
+
+    def _validate_number(self, value):
+        if isinstance(value, int):
+            if self._int_digit_count(value) > self.max_result_digits:
+                raise CalculationLimitError
+            return value
+        if isinstance(value, float):
+            if not math.isfinite(value):
+                raise CalculationLimitError
+            if self._float_digit_count(value) > self.max_result_digits:
+                raise CalculationLimitError
+            return value
+        raise ValueError
+
+    @staticmethod
+    def _int_digit_count(value):
+        return len(str(abs(value)))
+
+    @staticmethod
+    def _float_digit_count(value):
+        if value == 0:
+            return 1
+        return max(int(math.floor(math.log10(abs(value)))) + 1, 1)
+
+    def _validate_power_operands(self, base, exponent):
+        if base < 0 and not self._is_integer_value(exponent):
+            raise ValueError
+        if base == 0 or abs(base) == 1 or exponent == 0:
+            return
+
+        log10_base = math.log10(abs(base))
+        if log10_base > 0 and exponent >= self.max_result_digits / log10_base:
+            raise CalculationLimitError
+        if log10_base < 0 and exponent <= self.max_result_digits / log10_base:
+            raise CalculationLimitError
+
+    @staticmethod
+    def _is_integer_value(value):
+        return isinstance(value, int) or (isinstance(value, float) and value.is_integer())

--- a/modules/calculator.py
+++ b/modules/calculator.py
@@ -1,13 +1,31 @@
 import math
 import re
 
+SYNTAX_ERROR = "syntax error"
+DIVISION_BY_ZERO_ERROR = "division by zero error"
+CALC_LIMIT_ERROR = "calculation limit error"
 
-class CalculationLimitError(Exception):
-    pass
+
+class CalculatorError(Exception):
+    error_code = None
+
+
+class CalculatorSyntaxError(CalculatorError):
+    error_code = SYNTAX_ERROR
+
+
+class CalculatorDivisionByZeroError(CalculatorError):
+    error_code = DIVISION_BY_ZERO_ERROR
+
+
+class CalculationLimitError(CalculatorError):
+    error_code = CALC_LIMIT_ERROR
 
 
 class Calculator:
-    CALC_LIMIT_ERROR = "calculation limit error"
+    SYNTAX_ERROR = SYNTAX_ERROR
+    DIVISION_BY_ZERO_ERROR = DIVISION_BY_ZERO_ERROR
+    CALC_LIMIT_ERROR = CALC_LIMIT_ERROR
     MAX_EXPRESSION_LENGTH = 2000
     MAX_NUMBER_DIGITS = 1000
     MAX_RESULT_DIGITS = 1000
@@ -47,9 +65,7 @@ class Calculator:
         try:
             if len(expression) > self.max_expression_length:
                 raise CalculationLimitError
-            check = self.wrong_syntax_checker(expression)
-            if check == "syntax error":
-                return "syntax error"
+            self._validate_known_syntax(expression)
             tokens = self.tokenize(expression)
             postfix = self.infix_to_postfix(tokens)
 
@@ -59,15 +75,19 @@ class Calculator:
                 return result
             else:
                 return round(result, 4)
-        except CalculationLimitError:
-            return self.CALC_LIMIT_ERROR
-        except (TypeError, UnboundLocalError, IndexError, SyntaxError, ValueError, OverflowError):
-            return "syntax error"
-        except ZeroDivisionError:
-            return "division by zero error"
+        except CalculatorError as error:
+            return error.error_code
+        except (TypeError, UnboundLocalError, IndexError, ValueError, OverflowError):
+            return self.SYNTAX_ERROR
 
     # 정해진 연산자나 함수 이외의 텍스트가 있는지 체크
     def wrong_syntax_checker(self, expression):
+        try:
+            self._validate_known_syntax(expression)
+        except CalculatorSyntaxError:
+            return self.SYNTAX_ERROR
+
+    def _validate_known_syntax(self, expression):
         for i in sorted(self.library["function"], key=len, reverse=True):
             expression = re.sub(i, "", expression)
 
@@ -78,7 +98,7 @@ class Calculator:
         expression = re.sub(rule, "", expression)
 
         if expression != "":
-            return "syntax error"
+            raise CalculatorSyntaxError
 
     # 후위 연산 우선순위
     def priority(self, operator):
@@ -99,7 +119,7 @@ class Calculator:
     def tokenize(self, notation):
         text = notation.replace(" ", "")
         if not text:
-            raise SyntaxError
+            raise CalculatorSyntaxError
 
         # 정규식으로 토큰 추출 (함수명은 길이 역순으로 매칭)
         func_pattern = "|".join(sorted(self.library["function"], key=len, reverse=True))
@@ -108,7 +128,7 @@ class Calculator:
         tokens = re.findall(pattern, text)
 
         if "".join(tokens) != text:
-            raise SyntaxError
+            raise CalculatorSyntaxError
         if len(tokens) > self.max_tokens:
             raise CalculationLimitError
         for tok in tokens:
@@ -151,9 +171,9 @@ class Calculator:
             elif tok == ")":
                 depth -= 1
             if depth < 0:
-                raise SyntaxError
+                raise CalculatorSyntaxError
         if depth != 0:
-            raise SyntaxError
+            raise CalculatorSyntaxError
 
         return list(map(self.string_to_number, result))
 
@@ -246,6 +266,8 @@ class Calculator:
                     elif i == "*":
                         temp = num2 * num1
                     elif i == "/":
+                        if num1 == 0:
+                            raise CalculatorDivisionByZeroError
                         temp = num2 / num1
                     elif i == "^":
                         self._validate_power_operands(num2, num1)
@@ -253,7 +275,10 @@ class Calculator:
                 # 함수
                 elif i in self.library["function"]:
                     num = stack.pop()
-                    temp = self.function[i](num)
+                    try:
+                        temp = self.function[i](num)
+                    except (ValueError, OverflowError) as exc:
+                        raise CalculatorSyntaxError from exc
 
                 stack.append(self._validate_number(temp))
 
@@ -270,7 +295,7 @@ class Calculator:
             if self._float_digit_count(value) > self.max_result_digits:
                 raise CalculationLimitError
             return value
-        raise ValueError
+        raise CalculatorSyntaxError
 
     @staticmethod
     def _int_digit_count(value):
@@ -284,7 +309,9 @@ class Calculator:
 
     def _validate_power_operands(self, base, exponent):
         if base < 0 and not self._is_integer_value(exponent):
-            raise ValueError
+            raise CalculatorSyntaxError
+        if base == 0 and exponent < 0:
+            raise CalculatorDivisionByZeroError
         if base == 0 or abs(base) == 1 or exponent == 0:
             return
 

--- a/modules/features_hub.py
+++ b/modules/features_hub.py
@@ -145,6 +145,8 @@ class BotFeaturesHub:
                 self.bot.reply_to(message, strings.calc_syntax_error_msg)
             elif result == "division by zero error":
                 self.bot.reply_to(message, strings.calc_division_by_zero_error_msg)
+            elif result == Calculator.CALC_LIMIT_ERROR:
+                self.bot.reply_to(message, strings.calc_limit_error_msg)
             else:
                 self.bot.reply_to(message, result)
 

--- a/modules/features_hub.py
+++ b/modules/features_hub.py
@@ -141,9 +141,9 @@ class BotFeaturesHub:
 
             result = self.calculator.operation(actual_text)
 
-            if result == "syntax error":
+            if result == Calculator.SYNTAX_ERROR:
                 self.bot.reply_to(message, strings.calc_syntax_error_msg)
-            elif result == "division by zero error":
+            elif result == Calculator.DIVISION_BY_ZERO_ERROR:
                 self.bot.reply_to(message, strings.calc_division_by_zero_error_msg)
             elif result == Calculator.CALC_LIMIT_ERROR:
                 self.bot.reply_to(message, strings.calc_limit_error_msg)

--- a/resources/strings.py
+++ b/resources/strings.py
@@ -133,6 +133,7 @@ calc_syntax_error_msg = (
     "상수의 상수배인 경우 곱셈 기호(*)가 있는지 확인해 주세요."
 )
 calc_division_by_zero_error_msg = "0으로 나눌 수 없습니다."
+calc_limit_error_msg = "계산식 또는 결과가 너무 큽니다. 더 작은 숫자로 다시 시도해 주세요."
 
 # geolocation error message
 geolocation_error_msg = "위치 정보를 가져오는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -134,6 +134,60 @@ class TestErrors:
         assert calc.operation(" .5 + 1") == "syntax error"
 
 
+class TestCalculationLimits:
+    def test_power_tower_limit(self, calc):
+        assert calc.operation(" 9 ^ 9 ^ 9 ^ 9 ^ 9") == Calculator.CALC_LIMIT_ERROR
+
+    def test_power_tower_limit_without_spaces(self, calc):
+        assert calc.operation("9^9^9^9^9") == Calculator.CALC_LIMIT_ERROR
+
+    def test_minimal_dangerous_power_tower_limit(self, calc):
+        assert calc.operation("9^9^9") == Calculator.CALC_LIMIT_ERROR
+
+    def test_power_result_limit(self, calc):
+        assert calc.operation(" 10 ^ 1000") == Calculator.CALC_LIMIT_ERROR
+
+    def test_power_result_limit_allows_boundary(self, calc):
+        result = calc.operation(" 10 ^ 999")
+        assert isinstance(result, int)
+        assert len(str(result)) == calc.max_result_digits
+
+    def test_parenthesized_power_within_limit(self, calc):
+        assert calc.operation(" (9 ^ 9) ^ 9") == pow(pow(9, 9), 9)
+
+    def test_intermediate_result_limit(self):
+        calc = Calculator(max_result_digits=3)
+        assert calc.operation(" 99 * 99") == Calculator.CALC_LIMIT_ERROR
+
+    def test_intermediate_result_limit_allows_boundary(self):
+        calc = Calculator(max_result_digits=4)
+        assert calc.operation(" 99 * 99") == 9801
+
+    def test_number_token_digit_limit(self):
+        calc = Calculator(max_number_digits=3)
+        assert calc.operation(" 1000 + 1") == Calculator.CALC_LIMIT_ERROR
+
+    def test_number_token_digit_limit_allows_boundary(self):
+        number = "1" + "0" * 999
+        assert Calculator().operation(f" {number}") == int(number)
+
+    def test_expression_length_limit(self):
+        calc = Calculator(max_expression_length=5)
+        assert calc.operation(" 1 + 2 + 3") == Calculator.CALC_LIMIT_ERROR
+
+    def test_expression_length_limit_allows_boundary(self):
+        calc = Calculator(max_expression_length=5)
+        assert calc.operation("1 + 2") == 3
+
+    def test_transformed_token_limit(self):
+        calc = Calculator(max_tokens=1)
+        assert calc.operation("-1") == Calculator.CALC_LIMIT_ERROR
+
+    def test_transformed_token_limit_allows_boundary(self):
+        calc = Calculator(max_tokens=3)
+        assert calc.operation("-1") == -1
+
+
 class TestStringToNumber:
     def test_integer(self, calc):
         assert calc.string_to_number("42") == 42

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -80,58 +80,61 @@ class TestConstants:
 
 class TestErrors:
     def test_division_by_zero(self, calc):
-        assert calc.operation(" 1 / 0") == "division by zero error"
+        assert calc.operation(" 1 / 0") == Calculator.DIVISION_BY_ZERO_ERROR
 
     def test_division_by_zero_expression(self, calc):
-        assert calc.operation(" 1 / (2 - 2)") == "division by zero error"
+        assert calc.operation(" 1 / (2 - 2)") == Calculator.DIVISION_BY_ZERO_ERROR
+
+    def test_zero_to_negative_power(self, calc):
+        assert calc.operation(" 0 ^ -1") == Calculator.DIVISION_BY_ZERO_ERROR
 
     def test_syntax_error_letters(self, calc):
-        assert calc.operation(" abc") == "syntax error"
+        assert calc.operation(" abc") == Calculator.SYNTAX_ERROR
 
     def test_empty_expression(self, calc):
-        assert calc.operation("") == "syntax error"
+        assert calc.operation("") == Calculator.SYNTAX_ERROR
 
     def test_unbalanced_open_paren(self, calc):
-        assert calc.operation(" (2 + 3") == "syntax error"
+        assert calc.operation(" (2 + 3") == Calculator.SYNTAX_ERROR
 
     def test_unbalanced_close_paren(self, calc):
-        assert calc.operation(" 2 + 3)") == "syntax error"
+        assert calc.operation(" 2 + 3)") == Calculator.SYNTAX_ERROR
 
     def test_trailing_operator(self, calc):
-        assert calc.operation(" 2 +") == "syntax error"
+        assert calc.operation(" 2 +") == Calculator.SYNTAX_ERROR
 
     def test_double_operator(self, calc):
-        assert calc.operation(" 2 ++ 3") == "syntax error"
+        assert calc.operation(" 2 ++ 3") == Calculator.SYNTAX_ERROR
 
     def test_sqrt_negative(self, calc):
-        assert calc.operation(" sqrt(-1)") == "syntax error"
+        assert calc.operation(" sqrt(-1)") == Calculator.SYNTAX_ERROR
 
     def test_ln_zero(self, calc):
-        assert calc.operation(" ln(0)") == "syntax error"
+        assert calc.operation(" ln(0)") == Calculator.SYNTAX_ERROR
 
     def test_ln_negative(self, calc):
-        assert calc.operation(" ln(-1)") == "syntax error"
+        assert calc.operation(" ln(-1)") == Calculator.SYNTAX_ERROR
 
     def test_log_negative(self, calc):
-        assert calc.operation(" log(-1)") == "syntax error"
+        assert calc.operation(" log(-1)") == Calculator.SYNTAX_ERROR
 
     def test_asin_out_of_domain(self, calc):
-        assert calc.operation(" asin(2)") == "syntax error"
+        assert calc.operation(" asin(2)") == Calculator.SYNTAX_ERROR
 
     def test_acos_out_of_domain(self, calc):
-        assert calc.operation(" acos(2)") == "syntax error"
+        assert calc.operation(" acos(2)") == Calculator.SYNTAX_ERROR
 
     def test_exp_overflow(self, calc):
-        assert calc.operation(" exp(1000)") == "syntax error"
+        assert calc.operation(" exp(1000)") == Calculator.SYNTAX_ERROR
 
     def test_leading_operator(self, calc):
-        assert calc.operation(" * 2") == "syntax error"
+        assert calc.operation(" * 2") == Calculator.SYNTAX_ERROR
 
     def test_empty_parentheses(self, calc):
-        assert calc.operation(" ()") == "syntax error"
+        assert calc.operation(" ()") == Calculator.SYNTAX_ERROR
 
     def test_leading_dot_decimal(self, calc):
-        assert calc.operation(" .5 + 1") == "syntax error"
+        assert calc.operation(" .5 + 1") == Calculator.SYNTAX_ERROR
 
 
 class TestCalculationLimits:
@@ -219,10 +222,10 @@ class TestWrongSyntaxChecker:
         assert calc.wrong_syntax_checker("sqrt(4)") is None
 
     def test_invalid_characters(self, calc):
-        assert calc.wrong_syntax_checker("2 + abc") == "syntax error"
+        assert calc.wrong_syntax_checker("2 + abc") == Calculator.SYNTAX_ERROR
 
     def test_invalid_single_letter(self, calc):
-        assert calc.wrong_syntax_checker("x") == "syntax error"
+        assert calc.wrong_syntax_checker("x") == Calculator.SYNTAX_ERROR
 
     def test_asin_not_confused_with_sin(self, calc):
         assert calc.wrong_syntax_checker("asin(0.5)") is None
@@ -284,7 +287,7 @@ class TestOperationEdgeCases:
         assert calc.operation(" 999999 * 999999") == 999998000001
 
     def test_only_whitespace(self, calc):
-        assert calc.operation("   ") == "syntax error"
+        assert calc.operation("   ") == Calculator.SYNTAX_ERROR
 
     def test_complex_expression(self, calc):
         assert calc.operation(" 2 + 3 * 4 - 6 / 2") == 11.0

--- a/tests/test_features_hub.py
+++ b/tests/test_features_hub.py
@@ -96,6 +96,11 @@ class TestCalculatorHandler:
         hub.calculator_handler(msg)
         hub.bot.reply_to.assert_called_once_with(msg, strings.calc_division_by_zero_error_msg)
 
+    def test_calculation_limit_error(self, hub):
+        msg = make_message("/calc 9^9^9^9^9")
+        hub.calculator_handler(msg)
+        hub.bot.reply_to.assert_called_once_with(msg, strings.calc_limit_error_msg)
+
     def test_no_expression(self, hub):
         msg = make_message("/calc")
         hub.calculator_handler(msg)


### PR DESCRIPTION
## Summary
- 계산식 길이, token 수, 숫자 입력 자릿수, 중간 결과 자릿수 제한을 추가했습니다.
- 위험한 거듭제곱 표현식은 `pow()` 호출 전에 예상 결과 자릿수를 계산해 차단합니다.
- 계산기 에러 처리를 전용 exception과 공통 error code 상수로 정리했습니다.
- resource limit, division-by-zero, false positive 경계값에 대한 회귀 테스트를 추가했습니다.

## Changes
### Bug Fixes
- `9^9^9`, `9^9^9^9^9`처럼 worker thread를 장시간 점유할 수 있는 계산식을 차단합니다.
- 계산식 또는 결과가 너무 큰 경우 사용자에게 별도 limit error 메시지를 반환합니다.
- `/` 연산과 `0 ^ -1` 같은 케이스에서 division-by-zero 동작을 유지합니다.
- `10 ^ 999`, 1000자리 숫자 입력, `(9 ^ 9) ^ 9`처럼 제한 안에 있는 정상 경계값은 허용합니다.

### Refactoring
- syntax, division-by-zero, calculation-limit 에러를 계산기 전용 exception 계층으로 통일했습니다.
- handler와 테스트의 에러 비교를 문자열 리터럴 대신 `Calculator` error code 상수 기반으로 변경했습니다.

### Tests
- power tower, token count, expression length, 숫자 입력 자릿수, 결과 자릿수 제한 테스트를 추가했습니다.
- 정상 경계값이 오탐으로 막히지 않도록 boundary 테스트를 추가했습니다.
- 새 calculator limit error 응답에 대한 handler 테스트를 추가했습니다.

## Test plan
- [x] `.venv/bin/ruff check .`
- [x] `.venv/bin/ruff format --check .`
- [x] `.venv/bin/python -m pytest -v --cov --cov-report=term-missing --cov-report=xml`
- [x] 517 tests passed
- [x] Coverage: 94.22%