### PR TITLE
Harden release deployment integrity

### DIFF
--- a/.agents/skills/sungsimdangbot-git/SKILL.md
+++ b/.agents/skills/sungsimdangbot-git/SKILL.md
@@ -137,15 +137,19 @@ Versioning:
 
 CD behavior:
 
+- Verify that the release tag commit belongs to `master`.
 - Extract release version from the release tag.
 - Pass it as Docker build arg `VERSION`.
 - Build linux/amd64 and linux/arm64 images and push to GHCR.
+- Pass the pushed multi-platform image digest to the deploy job.
+- Gate deployment with the protected `production` GitHub Environment.
 - Connect to the deployment server through Tailscale and SSH.
-- Update `.env`, pull the image, and run `docker compose up -d`.
+- Update the application `.env` and the digest-pinned `.deploy.env`.
+- Pull and start the exact image digest with `docker compose --env-file .deploy.env`.
 
 CI/CD triggers:
 
 - Pull request created or updated: CI runs.
 - Push to `development`: CI runs.
 - Push to `master`: CI runs.
-- GitHub Release created: CD runs.
+- GitHub Release published: CD runs.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    target-branch: development

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,35 +4,60 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
+concurrency:
+  group: production-deployment
+  queue: max
+  cancel-in-progress: false
+
 jobs:
-  build-and-push:
+  build:
+    name: Build and push
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    outputs:
+      image: ${{ steps.image.outputs.name }}
+      digest: ${{ steps.build.outputs.digest }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: master
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+      - name: Verify release source
+        run: git merge-base --is-ancestor HEAD origin/master
       - name: Resolve version
         id: ver
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-      - uses: docker/setup-qemu-action@v4
-      - uses: docker/setup-buildx-action@v4
-      - uses: docker/login-action@v4
+        run: |
+          if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid release tag: $GITHUB_REF_NAME" >&2
+            exit 1
+          fi
+          echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - name: Resolve image name
+        id: image
+        env:
+          IMAGE_NAME: ghcr.io/${{ github.repository }}
+        run: echo "name=${IMAGE_NAME,,}" >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/metadata-action@v6
+      - uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         id: meta
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ${{ steps.image.outputs.name }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        id: build
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -45,28 +70,42 @@ jobs:
           cache-to: type=gha,mode=max
 
   deploy:
-    needs: build-and-push
+    name: Deploy
+    needs: build
     runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: master
+          ref: ${{ github.ref }}
           sparse-checkout: docker-compose.yml
           sparse-checkout-cone-mode: false
-      - uses: tailscale/github-action@v4
+      - name: Prepare deployment image
+        env:
+          IMAGE_NAME: ${{ needs.build.outputs.image }}
+          IMAGE_DIGEST: ${{ needs.build.outputs.digest }}
+        run: |
+          if [[ ! "$IMAGE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "Invalid image digest: $IMAGE_DIGEST" >&2
+            exit 1
+          fi
+          printf 'BOT_IMAGE=%s@%s\n' "$IMAGE_NAME" "$IMAGE_DIGEST" > .deploy.env
+      - uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:ci
-      - uses: appleboy/scp-action@v1
+      - uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1
         with:
           host: ${{ secrets.PI_TAILSCALE_IP }}
           username: ${{ secrets.PI_SSH_USER }}
           key: ${{ secrets.PI_SSH_KEY }}
           port: ${{ secrets.PI_SSH_PORT }}
-          source: "docker-compose.yml"
+          source: "docker-compose.yml,.deploy.env"
           target: "~/sungsimdangbot"
-      - uses: appleboy/ssh-action@v1
+      - uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
         with:
           host: ${{ secrets.PI_TAILSCALE_IP }}
           username: ${{ secrets.PI_SSH_USER }}
@@ -88,6 +127,7 @@ jobs:
             RSSF_TOKEN=${{ secrets.RSSF_TOKEN }}
             RSSF_URL=${{ secrets.RSSF_URL }}
             EOF
+            chmod 600 .env .deploy.env
             mkdir -p ~/sungsimdangbot/data
-            docker compose pull
-            docker compose up -d
+            docker compose --env-file .deploy.env pull
+            docker compose --env-file .deploy.env up -d

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,19 @@ on:
     branches: [master, development]
   pull_request:
 
+permissions: {}
+
 jobs:
   ci:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.10", "3.14"]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -29,16 +33,20 @@ jobs:
         run: pytest -v --cov --cov-report=term-missing --cov-report=xml
       - name: Upload coverage
         if: matrix.python-version == '3.14'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-report
           path: coverage.xml
   secrets:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_COMMENTS: "false"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,10 +179,12 @@ docker rm -f sungsimdangbot
 
 - CI는 GitHub Actions에서 `master`, `development`, 모든 PR에 대해 실행된다.
 - CI matrix는 Python 3.10과 3.14를 사용하며 `ruff check`, `ruff format --check`, pytest coverage를 실행한다.
+- Workflow의 Action 참조는 full commit SHA로 고정하고 Dependabot으로 갱신한다.
 - CD는 GitHub Release publish 이벤트에서 실행된다.
-- release tag `vX.Y.Z`에서 version을 추출해 Docker build arg `VERSION`으로 전달한다.
+- release tag `vX.Y.Z`의 commit이 `master` 이력에 포함되는지 확인하고 version을 Docker build arg `VERSION`으로 전달한다.
 - Docker 이미지는 `python:3.14-slim` 기반이며 linux/amd64, linux/arm64로 GHCR에 push된다.
-- 배포 job은 Tailscale과 SSH로 서버에 접속해 `.env`를 갱신하고 `docker compose pull && docker compose up -d`를 실행한다.
+- 배포 job은 `production` Environment 보호를 거쳐 Tailscale과 SSH로 서버에 접속한다.
+- 빌드가 출력한 image digest를 `.deploy.env`에 저장하고 동일 digest로 `docker compose pull`과 `up -d`를 실행한다.
 - 버전은 git tag가 단일 진실 공급원이다. `pyproject.toml`은 `dynamic = ["version"]`와 `setuptools-scm`을 사용한다.
 
 ## Agent Workflow

--- a/README.md
+++ b/README.md
@@ -97,10 +97,14 @@ docker rm -f sungsimdangbot
 ```
 
 `docker-compose.yml`은 GHCR production 이미지를 pull하는 배포용 설정입니다.
+CD가 생성한 `.deploy.env`에 배포할 image digest가 있어야 합니다.
 
 ```bash
-docker compose up -d
+docker compose --env-file .deploy.env up -d
 ```
+
+운영 서버에서는 `pull`, `up`, `ps`, `logs`, `restart`, `down`을 포함한 모든 `docker compose` 명령에
+`--env-file .deploy.env`를 사용합니다.
 
 ## 기능 목록
 
@@ -179,12 +183,14 @@ CI는 GitHub Actions에서 `master`, `development`, 모든 PR에 대해 실행�
 
 CD는 GitHub Release publish 이벤트에서 실행됩니다.
 
-1. Release tag `vX.Y.Z`에서 버전을 추출합니다.
-2. Docker image를 linux/amd64, linux/arm64로 빌드해 GHCR에 push합니다.
-3. Tailscale VPN으로 배포 서버에 접근합니다.
-4. SSH로 `.env`와 compose 상태를 갱신한 뒤 컨테이너를 재시작합니다.
+1. Release tag `vX.Y.Z`의 commit이 `master` 이력에 포함되는지 확인하고 버전을 추출합니다.
+2. Docker image를 linux/amd64, linux/arm64로 빌드해 GHCR에 push하고 image digest를 확정합니다.
+3. `production` GitHub Environment 승인을 거친 뒤 Tailscale VPN으로 배포 서버에 접근합니다.
+4. SSH로 애플리케이션 `.env`와 digest가 담긴 `.deploy.env`를 갱신합니다.
+5. `docker compose --env-file .deploy.env`로 빌드된 동일 digest의 컨테이너를 배포합니다.
 
 버전은 git tag가 단일 진실 공급원입니다. `pyproject.toml`은 `dynamic = ["version"]`와 `setuptools-scm`을 사용합니다.
+GitHub Actions는 full commit SHA로 고정하며 Dependabot이 `development` 대상 업데이트를 생성합니다.
 
 ## 필요한 GitHub Secrets
 
@@ -208,6 +214,10 @@ CD는 GitHub Release publish 이벤트에서 실행됩니다.
 | `ADMIN_USER_ID` | 관리자 텔레그램 사용자 ID |
 | `RSSF_TOKEN` | RSS 번역 서버 인증 토큰 |
 | `RSSF_URL` | RSS 번역 서버 URL |
+
+배포 job은 `production` GitHub Environment를 사용합니다. 저장소 설정에서 required reviewer를 지정하고,
+Selected branches and tags의 tag 규칙에 `v*.*.*`를 허용합니다. release tag commit의 `master` 포함 여부는 workflow가
+별도로 검증합니다. 운영 배포 secret은 가능한 이 Environment에 저장합니다.
 
 ## 기여자
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   bot:
-    image: ghcr.io/kry-p/sungsimdangbot:latest
+    image: "${BOT_IMAGE:?BOT_IMAGE must be set via .deploy.env}"
     container_name: sungsimdangbot
     restart: unless-stopped
     env_file:


### PR DESCRIPTION
## Summary
- GitHub Actions를 full commit SHA로 고정하고 Dependabot 업데이트를 구성
- release tag의 master 포함 여부를 검증하고 정확한 image digest를 배포
- production Environment와 최소 permissions로 배포 접근을 제한
- 변경된 Compose 및 릴리스 운영 절차를 문서화

## Changes
### CI/CD
- 모든 CI/CD Action을 검증된 full commit SHA로 고정
- workflow와 job에 명시적인 최소 permissions 적용
- GitHub Actions Dependabot 업데이트를 development 대상으로 설정
- production 배포를 순차 처리하도록 concurrency queue 구성

### Deployment
- release tag commit이 master 이력에 포함되는지 검증
- 빌드된 multi-platform image digest를 deploy job으로 전달
- docker-compose.yml이 BOT_IMAGE digest를 필수로 요구하도록 변경
- production Environment 승인 후 정확한 digest를 pull하고 실행

### Documentation
- README, AGENTS.md 및 git skill의 릴리스·배포 절차 갱신

## Test plan
- [x] Ruff lint 통과
- [x] Ruff format check 통과
- [x] 517 tests passed, coverage 94.22%
- [x] Docker Compose digest 치환 검증
- [x] BOT_IMAGE 누락 시 fail-closed 동작 검증
- [x] GitHub Action SHA 및 production Environment 설정 확인
