### PR TITLE
Fix RSSF bearer token authentication

### DIFF
--- a/modules/web_based.py
+++ b/modules/web_based.py
@@ -146,10 +146,11 @@ class WebManager:
         if slug not in strings.bfrss_feed_names:
             return strings.bfrss_unknown_slug_msg, None
         try:
-            params = {"token": config.RSSF_TOKEN}
+            headers = {"Authorization": f"Bearer {config.RSSF_TOKEN}"}
+            params = {}
             if date:
                 params["date"] = date
-            res = requests.get(f"{config.RSSF_URL.rstrip('/')}/feed/{slug}", params=params, timeout=10)
+            res = requests.get(f"{config.RSSF_URL.rstrip('/')}/feed/{slug}", headers=headers, params=params, timeout=10)
             res.raise_for_status()
             data = RssfResponse.model_validate_json(res.text)
             feed_name = strings.bfrss_feed_names[slug]

--- a/tests/test_web_based.py
+++ b/tests/test_web_based.py
@@ -301,7 +301,8 @@ class TestRssHandler:
             assert "&amp;chars" in text
             mock_get.assert_called_once_with(
                 "http://test-server/feed/hn",
-                params={"token": "test_token"},
+                headers={"Authorization": "Bearer test_token"},
+                params={},
                 timeout=10,
             )
 
@@ -320,7 +321,8 @@ class TestRssHandler:
             assert "LOBSTERS" in text
             mock_get.assert_called_once_with(
                 "http://test-server/feed/lob",
-                params={"token": "test_token"},
+                headers={"Authorization": "Bearer test_token"},
+                params={},
                 timeout=10,
             )
 
@@ -337,7 +339,8 @@ class TestRssHandler:
             wm.fetch_rss(slug="lob", date="20260507")
             mock_get.assert_called_once_with(
                 "http://test-server/feed/lob",
-                params={"token": "test_token", "date": "20260507"},
+                headers={"Authorization": "Bearer test_token"},
+                params={"date": "20260507"},
                 timeout=10,
             )
 


### PR DESCRIPTION
## Summary
- gemctl RSSF 서버 인증 방식 변경에 맞춰 `/bfrss` RSSF 요청에서 query string token 전송을 제거했습니다.
- `RSSF_TOKEN`을 `Authorization: Bearer <token>` header로 전송하도록 변경했습니다.
- 날짜 조회용 `date` query parameter는 기존대로 유지했습니다.
- RSSF 요청 테스트를 새 인증 방식에 맞게 갱신했습니다.

## Test
- `curl.exe -H "Authorization: Bearer $env:RSSF_TOKEN" "https://transfer.triple-superstrike.cc/feed/hn"`
- `curl.exe -i "https://transfer.triple-superstrike.cc/feed/hn"` → `401 Unauthorized`
- `pytest tests/test_web_based.py tests/test_features_hub.py`
- `ruff check modules/web_based.py tests/test_web_based.py`
- `ruff format --check modules/web_based.py tests/test_web_based.py`
- `git diff --check`