### PR TITLE
Harden commute scheduling and timezone handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,9 @@ SPOTIFY_CLIENT_SECRET=
 # Admin
 ADMIN_USER_ID=
 
+# Bot timezone (IANA name, defaults to Asia/Seoul)
+# TIMEZONE=Asia/Seoul
+
 # RSS feed translator API
 RSSF_TOKEN=
 RSSF_URL=

--- a/README.md
+++ b/README.md
@@ -155,10 +155,13 @@ AI 질문 기능은 allowlist에 등록된 채팅에서만 사용할 수 있습�
 | `AI_RATE_LIMIT` | | 채팅/사용자별 분당 AI 요청 제한, 기본값 `5` |
 | `AI_API_TIMEOUT` | | AI API 요청 timeout(초), 기본값 `60` |
 | `ADMIN_USER_ID` | | 관리자 텔레그램 사용자 ID |
+| `TIMEZONE` | | 출퇴근 계산 시간대, 기본값 `Asia/Seoul` |
 | `RSSF_TOKEN` | | RSS 번역 서버 인증 토큰 |
 | `RSSF_URL` | | RSS 번역 서버 URL |
 
 `AI_*` 값이 없으면 이전 Gemini 전용 이름인 `GEMINI_SESSION_TIMEOUT`, `GEMINI_MAX_HISTORY`, `GEMINI_RATE_LIMIT`, `GEMINI_API_TIMEOUT`도 fallback으로 읽습니다.
+
+`TIMEZONE`이 없거나 빈 값이면 `Asia/Seoul`을 사용합니다. 값을 지정할 때는 `UTC`, `America/New_York` 같은 IANA 시간대 이름을 사용해야 하며, 잘못된 값을 설정하면 봇이 시작되지 않습니다.
 
 ## 개발 명령어
 

--- a/config/config.py
+++ b/config/config.py
@@ -1,4 +1,5 @@
 import os
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from dotenv import load_dotenv
 
@@ -16,6 +17,14 @@ def _int_env_with_fallback(primary: str, fallback_key: str, default: int) -> int
     if v is not None:
         return int(v)
     return _int_env(fallback_key, default)
+
+
+def _timezone_env(key, default):
+    value = os.getenv(key) or default
+    try:
+        return ZoneInfo(value)
+    except ZoneInfoNotFoundError as exc:
+        raise RuntimeError(f"Invalid {key}: {value}") from exc
 
 
 # Telegram bot token 텔레그램 봇 토큰
@@ -47,6 +56,10 @@ AI_RATE_LIMIT = _int_env_with_fallback("AI_RATE_LIMIT", "GEMINI_RATE_LIMIT", 5)
 AI_API_TIMEOUT = _int_env_with_fallback("AI_API_TIMEOUT", "GEMINI_API_TIMEOUT", 60)
 
 ADMIN_USER_ID = _int_env("ADMIN_USER_ID", 0)
+
+# Bot timezone
+TIMEZONE = _timezone_env("TIMEZONE", "Asia/Seoul")
+
 
 # RSS feed translator API
 RSSF_TOKEN = os.getenv("RSSF_TOKEN", "")

--- a/modules/commute.py
+++ b/modules/commute.py
@@ -6,6 +6,7 @@ HOURS_PER_DAY = 24
 DAYS_PER_WEEK = 7
 MINUTES_PER_DAY = HOURS_PER_DAY * MINUTES_PER_HOUR
 MINUTES_PER_WEEK = DAYS_PER_WEEK * MINUTES_PER_DAY
+END_OF_DAY_TIME = "24:00"
 
 VALIDATION_ERROR_MESSAGES = {
     "hour_out_of_range": "hour must be between 0 and 23",
@@ -33,6 +34,13 @@ def parse_time_to_minutes(time_text):
     return hour * MINUTES_PER_HOUR + minute
 
 
+def parse_end_time_to_minutes(time_text):
+    if time_text == END_OF_DAY_TIME:
+        return MINUTES_PER_DAY
+
+    return parse_time_to_minutes(time_text)
+
+
 def parse_weekdays(value):
     weekdays = []
 
@@ -54,7 +62,7 @@ def parse_weekdays(value):
 def save_schedule(user_id, weekday_text, start_time_text, end_time_text):
     weekdays = parse_weekdays(weekday_text)
     start_time_minutes = parse_time_to_minutes(start_time_text)
-    end_time_minutes = parse_time_to_minutes(end_time_text)
+    end_time_minutes = parse_end_time_to_minutes(end_time_text)
 
     if start_time_minutes == end_time_minutes:
         raise ValueError(VALIDATION_ERROR_MESSAGES["same_start_and_end"])

--- a/modules/commute_manager.py
+++ b/modules/commute_manager.py
@@ -4,6 +4,7 @@ import time
 
 import telebot
 
+from config import config
 from modules.commute import (
     MINUTES_PER_HOUR,
     delete_all_schedules,
@@ -79,7 +80,7 @@ class CommuteManager:
 
     @staticmethod
     def get_current_commute_time():
-        now = datetime.datetime.now()
+        now = datetime.datetime.now(config.TIMEZONE)
 
         return now.weekday(), now.hour * MINUTES_PER_HOUR + now.minute
 

--- a/modules/commute_manager.py
+++ b/modules/commute_manager.py
@@ -31,13 +31,24 @@ class CommuteManager:
         return bool(data and ":" in data and data.split(":", 1)[0] in CALLBACK_PREFIXES)
 
     def handle_commute_callback(self, call):
-        action, value = call.data.split(":", 1)
+        parts = call.data.split(":")
+        if len(parts) != 3:
+            return
+
+        action, value, owner_id_text = parts
+        try:
+            owner_id = int(owner_id_text)
+        except ValueError:
+            return
+
+        if call.from_user.id != owner_id:
+            return
 
         if action == "commute":
             if value in {"set", "delete"}:
                 self._request_input(call, value)
             elif value == "clear":
-                self._show_clear_confirmation(call)
+                self._show_clear_confirmation(call, owner_id)
             elif value == "cancel":
                 self.bot.edit_message_text(
                     strings.commute_menu_cancelled_msg,
@@ -63,7 +74,7 @@ class CommuteManager:
         self.bot.reply_to(
             message,
             menu_text,
-            reply_markup=self._build_menu_keyboard(),
+            reply_markup=self._build_menu_keyboard(message.from_user.id),
         )
 
     @staticmethod
@@ -153,6 +164,8 @@ class CommuteManager:
     def _request_input(self, call, action):
         self._cleanup_expired_inputs()
         prompt = strings.commute_set_input_msg if action == "set" else strings.commute_delete_input_msg
+        original_message = getattr(call.message, "reply_to_message", None)
+        original_message_id = getattr(original_message, "message_id", None)
         self.bot.edit_message_reply_markup(
             call.message.chat.id,
             call.message.message_id,
@@ -161,7 +174,10 @@ class CommuteManager:
         sent = self.bot.send_message(
             call.message.chat.id,
             prompt,
-            reply_markup=telebot.types.ForceReply(selective=True),
+            reply_to_message_id=original_message_id,
+            reply_markup=telebot.types.ForceReply(
+                selective=original_message_id is not None,
+            ),
         )
         pending_key = (call.message.chat.id, sent.message_id)
         with self._pending_inputs_lock:
@@ -215,16 +231,16 @@ class CommuteManager:
             strings.commute_delete_success_msg.format(count=count),
         )
 
-    def _show_clear_confirmation(self, call):
+    def _show_clear_confirmation(self, call, owner_id):
         keyboard = telebot.types.InlineKeyboardMarkup()
         keyboard.row(
             telebot.types.InlineKeyboardButton(
                 strings.commute_confirm_btn,
-                callback_data="commute_clear:confirm",
+                callback_data=f"commute_clear:confirm:{owner_id}",
             ),
             telebot.types.InlineKeyboardButton(
                 strings.commute_cancel_btn,
-                callback_data="commute_clear:cancel",
+                callback_data=f"commute_clear:cancel:{owner_id}",
             ),
         )
         self.bot.edit_message_text(
@@ -275,26 +291,26 @@ class CommuteManager:
         return f"{hour:02d}:{minute:02d}"
 
     @staticmethod
-    def _build_menu_keyboard():
+    def _build_menu_keyboard(owner_id):
         keyboard = telebot.types.InlineKeyboardMarkup()
         keyboard.row(
             telebot.types.InlineKeyboardButton(
                 strings.commute_set_btn,
-                callback_data="commute:set",
+                callback_data=f"commute:set:{owner_id}",
             ),
             telebot.types.InlineKeyboardButton(
                 strings.commute_delete_btn,
-                callback_data="commute:delete",
+                callback_data=f"commute:delete:{owner_id}",
             ),
         )
         keyboard.row(
             telebot.types.InlineKeyboardButton(
                 strings.commute_clear_btn,
-                callback_data="commute:clear",
+                callback_data=f"commute:clear:{owner_id}",
             ),
             telebot.types.InlineKeyboardButton(
                 strings.commute_close_btn,
-                callback_data="commute:cancel",
+                callback_data=f"commute:cancel:{owner_id}",
             ),
         )
 

--- a/modules/features_hub.py
+++ b/modules/features_hub.py
@@ -286,8 +286,9 @@ class BotFeaturesHub:
         if any(kw in message.text for kw in strings.magic_conch_keywords):
             self.bot.reply_to(message, self.random_based_features.magic_conch())
 
-        if any(kw in message.text for kw in strings.commute_start_keywords):
+        has_commute_time_keyword = any(kw in message.text for kw in strings.commute_time_keywords)
+        if has_commute_time_keyword and any(kw in message.text for kw in strings.commute_start_keywords):
             self.commute_start_keyword_handler(message)
 
-        if any(kw in message.text for kw in strings.commute_end_keywords):
+        if has_commute_time_keyword and any(kw in message.text for kw in strings.commute_end_keywords):
             self.commute_end_keyword_handler(message)

--- a/resources/strings.py
+++ b/resources/strings.py
@@ -96,6 +96,7 @@ temp_keywords = ("수온", "자살")
 magic_conch_keywords = ("마법의 소라고둥", "마법의 소라고동")
 commute_start_keywords = ("출근",)
 commute_end_keywords = ("퇴근",)
+commute_time_keywords = ("시간",)
 
 # commute messages
 commute_weekday_names = ("월", "화", "수", "목", "금", "토", "일")

--- a/tests/test_commute.py
+++ b/tests/test_commute.py
@@ -9,6 +9,7 @@ from modules.commute import (
     get_schedules,
     minutes_until_end,
     minutes_until_start,
+    parse_end_time_to_minutes,
     parse_time_to_minutes,
     parse_weekdays,
     save_schedule,
@@ -28,6 +29,13 @@ class TestParseTime:
     def test_invalid_minute(self):
         with pytest.raises(ValueError):
             parse_time_to_minutes("09:60")
+
+    def test_end_time_accepts_end_of_day(self):
+        assert parse_end_time_to_minutes("24:00") == 24 * 60
+
+    def test_end_time_rejects_minutes_after_end_of_day(self):
+        with pytest.raises(ValueError):
+            parse_end_time_to_minutes("24:01")
 
 
 class TestParseWeekdays:
@@ -68,6 +76,19 @@ class TestSaveSchedule:
     def test_reject_same_start_and_end_time(self):
         with pytest.raises(ValueError):
             save_schedule(123, "월", "09:00", "09:00")
+
+        assert CommuteSchedule.select().count() == 0
+
+    def test_accept_end_of_day_only_as_end_time(self):
+        save_schedule(123, "월", "00:01", "24:00")
+
+        schedule = CommuteSchedule.get()
+        assert schedule.start_time_minutes == 1
+        assert schedule.end_time_minutes == 24 * 60
+
+    def test_reject_end_of_day_as_start_time(self):
+        with pytest.raises(ValueError):
+            save_schedule(123, "월", "24:00", "00:01")
 
         assert CommuteSchedule.select().count() == 0
 
@@ -232,6 +253,18 @@ class TestFindActiveSchedule:
         assert schedule is None
         assert remaining_minutes is None
 
+    def test_finds_shift_ending_at_end_of_day(self):
+        save_schedule(123, "월", "00:01", "24:00")
+
+        schedule, remaining_minutes = find_active_schedule(
+            user_id=123,
+            current_weekday=0,
+            current_time_minutes=23 * 60 + 59,
+        )
+
+        assert schedule.weekday == 0
+        assert remaining_minutes == 1
+
 
 class TestMinutesUntilEnd:
     def test_day_shift(self):
@@ -251,6 +284,15 @@ class TestMinutesUntilEnd:
         )
 
         assert result is None
+
+    def test_end_of_day(self):
+        result = minutes_until_end(
+            current_time_minutes=23 * 60 + 59,
+            start_time_minutes=1,
+            end_time_minutes=24 * 60,
+        )
+
+        assert result == 1
 
     def test_night_shift_before_midnight(self):
         result = minutes_until_end(

--- a/tests/test_commute_manager.py
+++ b/tests/test_commute_manager.py
@@ -1,9 +1,11 @@
 import time
 from concurrent.futures import ThreadPoolExecutor
-from unittest.mock import MagicMock
+from datetime import datetime
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from config import config
 from modules.commute import save_schedule
 from modules.commute_manager import CommuteManager
 from resources import strings
@@ -319,6 +321,16 @@ class TestCommuteCallbacks:
 
 
 class TestCommuteKeywords:
+    @patch("modules.commute_manager.datetime.datetime")
+    def test_current_time_uses_configured_timezone(self, datetime_mock):
+        datetime_mock.now.return_value = datetime(2026, 8, 5, 16, 31)
+
+        weekday, minutes = CommuteManager.get_current_commute_time()
+
+        datetime_mock.now.assert_called_once_with(config.TIMEZONE)
+        assert weekday == 2
+        assert minutes == 16 * 60 + 31
+
     def test_start_keyword(self):
         save_schedule(123, "월", "09:00", "18:00")
         bot = MagicMock()

--- a/tests/test_commute_manager.py
+++ b/tests/test_commute_manager.py
@@ -29,10 +29,10 @@ class TestCommuteMenu:
 
         callback_data = [button.callback_data for row in kwargs["reply_markup"].keyboard for button in row]
         assert callback_data == [
-            "commute:set",
-            "commute:delete",
-            "commute:clear",
-            "commute:cancel",
+            "commute:set:123",
+            "commute:delete:123",
+            "commute:clear:123",
+            "commute:cancel:123",
         ]
 
     def test_shows_user_schedules_in_readable_format(self):
@@ -63,10 +63,13 @@ class TestCommuteCallbacks:
     @staticmethod
     def make_callback(data, user_id=123, chat_id=1, message_id=10):
         call = MagicMock()
-        call.data = data
+        call.data = f"{data}:{user_id}" if data.count(":") == 1 else data
         call.from_user.id = user_id
         call.message.chat.id = chat_id
         call.message.message_id = message_id
+        original_message = make_message("/commute", user_id=user_id, chat_id=chat_id)
+        original_message.message_id = message_id - 1
+        call.message.reply_to_message = original_message
         return call
 
     def test_set_button_requests_input_and_saves_reply(self):
@@ -84,6 +87,8 @@ class TestCommuteCallbacks:
             call.message.chat.id,
             strings.commute_set_input_msg,
         )
+        assert bot.send_message.call_args.kwargs["reply_to_message_id"] == call.message.reply_to_message.message_id
+        assert bot.send_message.call_args.kwargs["reply_markup"].selective is True
 
         reply = make_message("월화 09:00 18:00", user_id=123)
         reply.reply_to_message = prompt_message
@@ -95,6 +100,20 @@ class TestCommuteCallbacks:
             reply,
             strings.commute_set_success_msg.format(count=2),
         )
+
+    def test_set_prompt_falls_back_to_non_selective_force_reply_without_original_message(self):
+        bot = MagicMock()
+        prompt_message = MagicMock()
+        prompt_message.message_id = 99
+        bot.send_message.return_value = prompt_message
+        manager = CommuteManager(bot)
+        call = self.make_callback("commute:set")
+        call.message.reply_to_message = None
+
+        manager.handle_commute_callback(call)
+
+        assert bot.send_message.call_args.kwargs["reply_to_message_id"] is None
+        assert bot.send_message.call_args.kwargs["reply_markup"].selective is False
 
     def test_delete_button_requests_input_and_deletes_reply(self):
         save_schedule(123, "월화", "09:00", "18:00")
@@ -170,8 +189,8 @@ class TestCommuteCallbacks:
         )
         callback_data = [button.callback_data for row in kwargs["reply_markup"].keyboard for button in row]
         assert callback_data == [
-            "commute_clear:confirm",
-            "commute_clear:cancel",
+            "commute_clear:confirm:123",
+            "commute_clear:cancel:123",
         ]
 
         confirm_call = self.make_callback("commute_clear:confirm")
@@ -211,6 +230,31 @@ class TestCommuteCallbacks:
             call.message.chat.id,
             call.message.message_id,
         )
+
+    @pytest.mark.parametrize(
+        "callback_data",
+        (
+            "commute:set:123",
+            "commute:delete:123",
+            "commute:clear:123",
+            "commute:cancel:123",
+            "commute_clear:confirm:123",
+            "commute_clear:cancel:123",
+        ),
+    )
+    def test_other_user_cannot_use_commute_menu(self, callback_data):
+        save_schedule(123, "월", "09:00", "18:00")
+        bot = MagicMock()
+        manager = CommuteManager(bot)
+        call = self.make_callback(callback_data, user_id=456)
+
+        manager.handle_commute_callback(call)
+
+        assert manager._build_schedule_text(123) == "월 09:00~18:00"
+        assert manager._pending_inputs == {}
+        bot.send_message.assert_not_called()
+        bot.edit_message_text.assert_not_called()
+        bot.edit_message_reply_markup.assert_not_called()
 
     def test_other_user_cannot_consume_pending_input(self):
         bot = MagicMock()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,8 @@
 import importlib
 from unittest.mock import patch
 
+import pytest
+
 from config.config import _int_env
 
 
@@ -47,3 +49,31 @@ class TestOpenAIBaseURL:
         with patch.dict("os.environ", {}, clear=True):
             c = self._reload()
             assert c.OPENAI_BASE_URL == "https://api.openai.com/v1"
+
+
+class TestTimezone:
+    def _reload(self):
+        import config.config as c
+
+        importlib.reload(c)
+        return c
+
+    def test_missing_timezone_uses_seoul(self):
+        with patch.dict("os.environ", {}, clear=True):
+            c = self._reload()
+            assert c.TIMEZONE.key == "Asia/Seoul"
+
+    def test_empty_timezone_uses_seoul(self):
+        with patch.dict("os.environ", {"TIMEZONE": ""}):
+            c = self._reload()
+            assert c.TIMEZONE.key == "Asia/Seoul"
+
+    def test_custom_timezone(self):
+        with patch.dict("os.environ", {"TIMEZONE": "UTC"}):
+            c = self._reload()
+            assert c.TIMEZONE.key == "UTC"
+
+    def test_invalid_timezone(self):
+        with patch.dict("os.environ", {"TIMEZONE": "Invalid/Timezone"}):
+            with pytest.raises(RuntimeError, match="Invalid TIMEZONE: Invalid/Timezone"):
+                self._reload()

--- a/tests/test_features_hub.py
+++ b/tests/test_features_hub.py
@@ -148,21 +148,33 @@ class TestOrdinaryMessage:
         all_sentences = [s for group in strings.magic_conch_sentence for s in group]
         assert hub.bot.reply_to.call_args[0][1] in all_sentences
 
-    def test_commute_start_keyword(self, hub):
+    @pytest.mark.parametrize("text", ["출근 시간", "출근시간 알려줘", "오늘 출근 시간이 몇 시야?"])
+    def test_commute_start_keyword(self, hub, text):
         hub.commute.handle_start_keyword = MagicMock()
-        msg = make_message("출근")
+        msg = make_message(text)
 
         hub.ordinary_message(msg)
 
         hub.commute.handle_start_keyword.assert_called_once_with(msg)
 
-    def test_commute_end_keyword(self, hub):
+    @pytest.mark.parametrize("text", ["퇴근 시간", "퇴근시간 알려줘", "퇴근 시간 얼마나 남았어?"])
+    def test_commute_end_keyword(self, hub, text):
         hub.commute.handle_end_keyword = MagicMock()
-        msg = make_message("퇴근")
+        msg = make_message(text)
 
         hub.ordinary_message(msg)
 
         hub.commute.handle_end_keyword.assert_called_once_with(msg)
+
+    @pytest.mark.parametrize("text", ["출근", "퇴근", "출근을 안 찍었으니까", "퇴근하고 밥 먹자"])
+    def test_commute_keyword_without_time_does_not_trigger(self, hub, text):
+        hub.commute.handle_start_keyword = MagicMock()
+        hub.commute.handle_end_keyword = MagicMock()
+
+        hub.ordinary_message(make_message(text))
+
+        hub.commute.handle_start_keyword.assert_not_called()
+        hub.commute.handle_end_keyword.assert_not_called()
 
     def test_normal_message_no_action(self, hub):
         msg = make_message("안녕하세요")


### PR DESCRIPTION
  ## Summary
  - 출퇴근 입력 안내를 최초 호출자의 메시지에 연결해 단체 채팅에서 일정이 제대로 등록되지 않던 문제를 해결했습니다.
  - `/commute` 메뉴를 호출한 사용자만 버튼을 조작할 수 있도록 개선했습니다.
  - 출퇴근 계산에 설정 가능한 시간대를 적용했습니다.
  - 일반 대화의 `출근`, `퇴근`에 너무 과도하게 반응하던 문제를 해결하기 위해 `시간` 키워드를 함께 입력해야 반응하도록 수정했습니다.

  ## Changes

  ### Commute menu ownership
  - 메뉴를 생성할 때 호출자의 Telegram 사용자 ID를 각 버튼의 callback data에 포함했습니다.
    - `commute:set:<owner_id>`
    - `commute:delete:<owner_id>`
    - `commute:clear:<owner_id>`
    - `commute:cancel:<owner_id>`
  - 버튼 클릭 시 callback data를 분리해 메뉴 소유자 ID를 가져옵니다.
  - 실제 버튼을 누른 사용자 ID와 메뉴 소유자 ID가 일치할 때만 기능을 실행합니다.
  - 전체 삭제의 확인·취소 버튼에도 동일한 소유자 ID를 전달해 다음 단계에서도 소유권을 유지합니다.
  - 다른 사용자가 버튼을 눌러도 일정이나 입력 대기 상태가 변경되지 않습니다.

  ### Group chat input
  - 일정 등록·삭제 안내를 최초 `/commute` 메시지에 대한 답장으로 전송합니다.
  - Telegram이 단체 채팅에서도 `ForceReply` 대상 사용자를 명확히 식별할 수 있도록 했습니다.
  - 원본 `/commute` 메시지를 찾은 경우에만 selective `ForceReply`를 사용합니다.
  - 다른 사용자의 버튼 클릭이나 답장이 호출자의 일정 등록 절차에 영향을 주지 않는지 확인하는 pytest 테스트 케이스를 추가했습니다.
  - 다른 사용자가 입력 안내에 답장해도 호출자의 입력 대기 상태는 유지됩니다.

  ### Timezone
  - `TIMEZONE` 환경변수를 추가했습니다.
  - 값이 없거나 빈 값이면 `Asia/Seoul`을 사용합니다.
  - `UTC`, `America/New_York` 등의 IANA 시간대 이름을 지원합니다.
  - 잘못된 시간대를 설정하면 봇 시작 단계에서 오류로 처리합니다.
  - 출퇴근 현재 시각 계산에 설정된 시간대를 적용했습니다.
  - README와 `.env.example`에 시간대 설정 방법을 추가했습니다.

  ### Commute keyword matching
  - `출근` 또는 `퇴근`만 포함된 일반 대화에는 반응하지 않도록 변경했습니다.
  - `출근/퇴근`과 `시간` 키워드가 함께 포함된 경우에만 근무 시간 응답을 처리합니다.

  ### End-of-day time
  - 퇴근 시각에 한해 `24:00` 입력을 허용합니다.
  - `24:00`은 하루 종료 시각인 1440분으로 저장합니다.
  - 출근 시각의 `24:00`은 계속 거부합니다.
  - `24:01`, `24:59`, `25:00` 등의 유효하지 않은 시간도 계속 거부합니다.
  - `00:00~24:00`과 같은 하루 전체 일정도 표현할 수 있습니다.

  ## Related issues
  - #88 
  - #90

  운영 환경에서 동작을 확인한 후 관련 이슈를 종료합니다.

  ## Test plan
  - [x] 전체 테스트 613개 통과
  - [x] 전체 coverage 94.64%
  - [x] Ruff lint 검사 통과
  - [x] Ruff format 검사 통과
  - [x] `python:3.14-slim` 기반 로컬 이미지 빌드 성공
  - [x] 컨테이너에서 `Asia/Seoul` 시간대 적용 및 출퇴근 시간 계산 확인
  - [x] 테스트 Telegram 봇 polling 실행 확인
  - [x] 개인 채팅에서 출퇴근 시간 키워드 응답 확인
  - [x] 단체 채팅에서 출퇴근 시간 키워드 응답 확인
  - [x] 퇴근 시각 `24:00` 일정 등록 및 계산 확인


