### PR TITLE
Split long BFRSS responses into Telegram-safe messages

### DIFF
--- a/modules/features_hub.py
+++ b/modules/features_hub.py
@@ -264,8 +264,10 @@ class BotFeaturesHub:
         if error == "invalid_date":
             self.bot.reply_to(message, strings.bfrss_invalid_date_msg)
             return
-        text, parse_mode = self.web_manager.fetch_rss(slug, date)
-        self.bot.reply_to(message, text, parse_mode=parse_mode)
+        messages, parse_mode = self.web_manager.fetch_rss(slug, date)
+        for text in messages[:-1]:
+            self.bot.send_message(message.chat.id, text, parse_mode=parse_mode)
+        self.bot.reply_to(message, messages[-1], parse_mode=parse_mode)
 
     def commute_start_keyword_handler(self, message):
         self.commute.handle_start_keyword(message)

--- a/modules/features_hub.py
+++ b/modules/features_hub.py
@@ -264,10 +264,11 @@ class BotFeaturesHub:
         if error == "invalid_date":
             self.bot.reply_to(message, strings.bfrss_invalid_date_msg)
             return
-        messages, parse_mode = self.web_manager.fetch_rss(slug, date)
-        for text in messages[:-1]:
-            self.bot.send_message(message.chat.id, text, parse_mode=parse_mode)
-        self.bot.reply_to(message, messages[-1], parse_mode=parse_mode)
+        messages = self.web_manager.fetch_rss(slug, date)
+        for text, entities in messages[:-1]:
+            self.bot.send_message(message.chat.id, text, entities=[entity.to_dict() for entity in entities])
+        text, entities = messages[-1]
+        self.bot.reply_to(message, text, entities=[entity.to_dict() for entity in entities])
 
     def commute_start_keyword_handler(self, message):
         self.commute.handle_start_keyword(message)

--- a/modules/web_based.py
+++ b/modules/web_based.py
@@ -1,8 +1,8 @@
 import datetime
-import html
 import urllib.parse
 
 import requests
+from telegramify_markdown import MessageEntity, split_entities, utf16_len
 
 from config import config
 from modules import log
@@ -24,41 +24,8 @@ SEARCH_BASE_URL = config.SEARCH_BASE_URL
 MAP_BASE_URL = "https://dapi.kakao.com/v2/local/geo/coord2address.json?"
 WEATHER_BASE_URL = "https://api.openweathermap.org/data/2.5/weather?"
 SUON_REFRESH_INTERVAL = 600  # seconds
-# Telegram Bot API의 4096자 제한에 여유를 두고, non-BMP 문자도 보수적으로 계산한다.
+# Telegram Bot API의 4096자 제한에 여유를 둔다.
 BFRSS_MESSAGE_MAX_UTF16_LENGTH = 4090
-
-
-def _utf16_length(text):
-    return len(text.encode("utf-16-le", errors="surrogatepass")) // 2
-
-
-def _split_text_by_utf16(text, max_length):
-    if not text:
-        return [""]
-
-    chunks = []
-    remaining = text
-    while _utf16_length(remaining) > max_length:
-        current_length = 0
-        end = 0
-        for index, character in enumerate(remaining):
-            character_length = _utf16_length(character)
-            if current_length + character_length > max_length:
-                break
-            current_length += character_length
-            end = index + 1
-
-        if end == 0:
-            raise ValueError("max_length is too small for the next character")
-
-        candidate = remaining[:end]
-        boundary = max(candidate.rfind("\n"), candidate.rfind(" "))
-        split_at = boundary + 1 if boundary >= 0 else end
-        chunks.append(remaining[:split_at])
-        remaining = remaining[split_at:]
-
-    chunks.append(remaining)
-    return chunks
 
 
 # 강물 온도 조회
@@ -179,7 +146,7 @@ class WebManager:
 
     def fetch_rss(self, slug="hn", date=""):
         if slug not in strings.bfrss_feed_names:
-            return [strings.bfrss_unknown_slug_msg], None
+            return [(strings.bfrss_unknown_slug_msg, [])]
         try:
             headers = {"Authorization": f"Bearer {config.RSSF_TOKEN}"}
             params = {}
@@ -189,10 +156,10 @@ class WebManager:
             res.raise_for_status()
             data = RssfResponse.model_validate_json(res.text)
             feed_name = strings.bfrss_feed_names[slug]
-            return self._build_rss_messages(data, feed_name), "HTML"
+            return self._build_rss_messages(data, feed_name)
         except Exception as e:
             logger.log_error(f"rss_handler failed: {e}")
-            return [strings.bfrss_error_msg], None
+            return [(strings.bfrss_error_msg, [])]
 
     @staticmethod
     def _build_rss_header(data, feed_name):
@@ -213,44 +180,30 @@ class WebManager:
     @classmethod
     def _build_rss_messages(cls, data, feed_name):
         header = cls._build_rss_header(data, feed_name)
-        entry_count = len(data.entries)
-        if entry_count == 0:
-            return [header]
+        entry_prefix = strings.bfrss_entry_msg.format(title="")
+        entry_prefix_length = utf16_len(entry_prefix)
+        text_parts = [header]
+        entities = []
+        current_offset = utf16_len(header)
 
-        entry_prefix_length = _utf16_length(strings.bfrss_entry_plain_msg.format(title=""))
-        max_title_length = BFRSS_MESSAGE_MAX_UTF16_LENGTH - entry_prefix_length - _utf16_length(header)
-        entries = []
-        for entry in data.entries:
-            escaped_link = html.escape(entry.link, quote=True)
-            for title_part in _split_text_by_utf16(entry.title, max_title_length):
-                entries.append(
-                    (
-                        strings.bfrss_entry_msg.format(
-                            link=escaped_link,
-                            title=html.escape(title_part),
-                        ),
-                        strings.bfrss_entry_plain_msg.format(title=title_part),
+        for index, entry in enumerate(data.entries):
+            separator = "\n" if index else ""
+            entry_text = strings.bfrss_entry_msg.format(title=entry.title)
+            title_offset = current_offset + utf16_len(separator) + entry_prefix_length
+            if entry.title and entry.link:
+                entities.append(
+                    MessageEntity(
+                        type="text_link",
+                        offset=title_offset,
+                        length=utf16_len(entry.title),
+                        url=entry.link,
                     )
                 )
+            text_parts.extend((separator, entry_text))
+            current_offset += utf16_len(separator + entry_text)
 
-        messages = []
-        current_html = header
-        current_plain = header
-        current_entry_count = 0
-
-        for entry_html, entry_plain in entries:
-            separator = "\n" if current_entry_count else ""
-            candidate_plain = current_plain + separator + entry_plain
-            if _utf16_length(candidate_plain) > BFRSS_MESSAGE_MAX_UTF16_LENGTH:
-                messages.append(current_html)
-                current_html = entry_html
-                current_plain = entry_plain
-                current_entry_count = 1
-                continue
-
-            current_html += separator + entry_html
-            current_plain = candidate_plain
-            current_entry_count += 1
-
-        messages.append(current_html)
-        return messages
+        return split_entities(
+            "".join(text_parts),
+            entities,
+            max_utf16_len=BFRSS_MESSAGE_MAX_UTF16_LENGTH,
+        )

--- a/modules/web_based.py
+++ b/modules/web_based.py
@@ -24,6 +24,41 @@ SEARCH_BASE_URL = config.SEARCH_BASE_URL
 MAP_BASE_URL = "https://dapi.kakao.com/v2/local/geo/coord2address.json?"
 WEATHER_BASE_URL = "https://api.openweathermap.org/data/2.5/weather?"
 SUON_REFRESH_INTERVAL = 600  # seconds
+# Telegram Bot API의 4096자 제한에 여유를 두고, non-BMP 문자도 보수적으로 계산한다.
+BFRSS_MESSAGE_MAX_UTF16_LENGTH = 4090
+
+
+def _utf16_length(text):
+    return len(text.encode("utf-16-le", errors="surrogatepass")) // 2
+
+
+def _split_text_by_utf16(text, max_length):
+    if not text:
+        return [""]
+
+    chunks = []
+    remaining = text
+    while _utf16_length(remaining) > max_length:
+        current_length = 0
+        end = 0
+        for index, character in enumerate(remaining):
+            character_length = _utf16_length(character)
+            if current_length + character_length > max_length:
+                break
+            current_length += character_length
+            end = index + 1
+
+        if end == 0:
+            raise ValueError("max_length is too small for the next character")
+
+        candidate = remaining[:end]
+        boundary = max(candidate.rfind("\n"), candidate.rfind(" "))
+        split_at = boundary + 1 if boundary >= 0 else end
+        chunks.append(remaining[:split_at])
+        remaining = remaining[split_at:]
+
+    chunks.append(remaining)
+    return chunks
 
 
 # 강물 온도 조회
@@ -144,7 +179,7 @@ class WebManager:
 
     def fetch_rss(self, slug="hn", date=""):
         if slug not in strings.bfrss_feed_names:
-            return strings.bfrss_unknown_slug_msg, None
+            return [strings.bfrss_unknown_slug_msg], None
         try:
             headers = {"Authorization": f"Bearer {config.RSSF_TOKEN}"}
             params = {}
@@ -154,20 +189,68 @@ class WebManager:
             res.raise_for_status()
             data = RssfResponse.model_validate_json(res.text)
             feed_name = strings.bfrss_feed_names[slug]
-            if data.hour is not None:
-                time_of_day = strings.bfrss_am if data.hour < 12 else strings.bfrss_pm
-                text = strings.bfrss_header_msg.format(
-                    feed_name=feed_name, month=data.date[4:6], day=data.date[6:], time_of_day=time_of_day
-                )
-            else:
-                text = strings.bfrss_header_msg_no_time.format(
-                    feed_name=feed_name, month=data.date[4:6], day=data.date[6:]
-                )
-            text += "\n".join(
-                strings.bfrss_entry_msg.format(link=html.escape(e.link, quote=True), title=html.escape(e.title))
-                for e in data.entries
-            )
-            return text, "HTML"
+            return self._build_rss_messages(data, feed_name), "HTML"
         except Exception as e:
             logger.log_error(f"rss_handler failed: {e}")
-            return strings.bfrss_error_msg, None
+            return [strings.bfrss_error_msg], None
+
+    @staticmethod
+    def _build_rss_header(data, feed_name):
+        if data.hour is not None:
+            time_of_day = strings.bfrss_am if data.hour < 12 else strings.bfrss_pm
+            return strings.bfrss_header_msg.format(
+                feed_name=feed_name,
+                month=data.date[4:6],
+                day=data.date[6:],
+                time_of_day=time_of_day,
+            )
+        return strings.bfrss_header_msg_no_time.format(
+            feed_name=feed_name,
+            month=data.date[4:6],
+            day=data.date[6:],
+        )
+
+    @classmethod
+    def _build_rss_messages(cls, data, feed_name):
+        header = cls._build_rss_header(data, feed_name)
+        entry_count = len(data.entries)
+        if entry_count == 0:
+            return [header]
+
+        entry_prefix_length = _utf16_length(strings.bfrss_entry_plain_msg.format(title=""))
+        max_title_length = BFRSS_MESSAGE_MAX_UTF16_LENGTH - entry_prefix_length - _utf16_length(header)
+        entries = []
+        for entry in data.entries:
+            escaped_link = html.escape(entry.link, quote=True)
+            for title_part in _split_text_by_utf16(entry.title, max_title_length):
+                entries.append(
+                    (
+                        strings.bfrss_entry_msg.format(
+                            link=escaped_link,
+                            title=html.escape(title_part),
+                        ),
+                        strings.bfrss_entry_plain_msg.format(title=title_part),
+                    )
+                )
+
+        messages = []
+        current_html = header
+        current_plain = header
+        current_entry_count = 0
+
+        for entry_html, entry_plain in entries:
+            separator = "\n" if current_entry_count else ""
+            candidate_plain = current_plain + separator + entry_plain
+            if _utf16_length(candidate_plain) > BFRSS_MESSAGE_MAX_UTF16_LENGTH:
+                messages.append(current_html)
+                current_html = entry_html
+                current_plain = entry_plain
+                current_entry_count = 1
+                continue
+
+            current_html += separator + entry_html
+            current_plain = candidate_plain
+            current_entry_count += 1
+
+        messages.append(current_html)
+        return messages

--- a/modules/web_based.py
+++ b/modules/web_based.py
@@ -24,7 +24,7 @@ SEARCH_BASE_URL = config.SEARCH_BASE_URL
 MAP_BASE_URL = "https://dapi.kakao.com/v2/local/geo/coord2address.json?"
 WEATHER_BASE_URL = "https://api.openweathermap.org/data/2.5/weather?"
 SUON_REFRESH_INTERVAL = 600  # seconds
-# Telegram Bot API의 4096자 제한에 여유를 둔다.
+# Telegram Bot API의 4096자 제한에 여유를 둔 바운더리 설정.
 BFRSS_MESSAGE_MAX_UTF16_LENGTH = 4090
 
 

--- a/resources/strings.py
+++ b/resources/strings.py
@@ -338,8 +338,7 @@ bfrss_am = "오전"
 bfrss_pm = "오후"
 bfrss_header_msg = " {feed_name} ({month}월 {day}일 {time_of_day})\n\n"
 bfrss_header_msg_no_time = " {feed_name} ({month}월 {day}일)\n\n"
-bfrss_entry_msg = '• <a href="{link}">{title}</a>'
-bfrss_entry_plain_msg = "• {title}"
+bfrss_entry_msg = "• {title}"
 bfrss_feed_names = {"hn": "THE HACKER NEWS", "lob": "LOBSTERS", "reg": "THE REGISTER"}
 
 # Resources

--- a/resources/strings.py
+++ b/resources/strings.py
@@ -339,6 +339,7 @@ bfrss_pm = "오후"
 bfrss_header_msg = " {feed_name} ({month}월 {day}일 {time_of_day})\n\n"
 bfrss_header_msg_no_time = " {feed_name} ({month}월 {day}일)\n\n"
 bfrss_entry_msg = '• <a href="{link}">{title}</a>'
+bfrss_entry_plain_msg = "• {title}"
 bfrss_feed_names = {"hn": "THE HACKER NEWS", "lob": "LOBSTERS", "reg": "THE REGISTER"}
 
 # Resources

--- a/tests/test_features_hub.py
+++ b/tests/test_features_hub.py
@@ -2,6 +2,7 @@ import datetime
 from unittest.mock import MagicMock, call, patch
 
 import pytest
+from telegramify_markdown import MessageEntity
 
 from modules.features_hub import BotFeaturesHub
 from resources import strings
@@ -369,26 +370,32 @@ class TestParseBfrssArgs:
 
 class TestBfrssHandler:
     def test_sends_only_last_chunk_as_reply(self, hub):
-        hub.web_manager.fetch_rss.return_value = (["first", "middle", "last"], "HTML")
+        first_entity = MessageEntity(type="text_link", offset=0, length=5, url="https://example.com/first")
+        last_entity = MessageEntity(type="text_link", offset=0, length=4, url="https://example.com/last")
+        hub.web_manager.fetch_rss.return_value = [
+            ("first", [first_entity]),
+            ("middle", []),
+            ("last", [last_entity]),
+        ]
         msg = make_message("/bfrss")
 
         hub.rss_handler(msg)
 
         assert hub.bot.send_message.call_args_list == [
-            call(msg.chat.id, "first", parse_mode="HTML"),
-            call(msg.chat.id, "middle", parse_mode="HTML"),
+            call(msg.chat.id, "first", entities=[first_entity.to_dict()]),
+            call(msg.chat.id, "middle", entities=[]),
         ]
-        hub.bot.reply_to.assert_called_once_with(msg, "last", parse_mode="HTML")
+        hub.bot.reply_to.assert_called_once_with(msg, "last", entities=[last_entity.to_dict()])
 
     def test_single_chunk_is_sent_as_reply(self, hub):
-        hub.web_manager.fetch_rss.return_value = (["only"], "HTML")
+        hub.web_manager.fetch_rss.return_value = [("only", [])]
         msg = make_message("/bfrss -lob 260507")
 
         hub.rss_handler(msg)
 
         hub.web_manager.fetch_rss.assert_called_once_with("lob", "20260507")
         hub.bot.send_message.assert_not_called()
-        hub.bot.reply_to.assert_called_once_with(msg, "only", parse_mode="HTML")
+        hub.bot.reply_to.assert_called_once_with(msg, "only", entities=[])
 
 
 class TestClearChatHandler:

--- a/tests/test_features_hub.py
+++ b/tests/test_features_hub.py
@@ -1,5 +1,5 @@
 import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -365,6 +365,30 @@ class TestParseBfrssArgs:
     def test_invalid_date_non_numeric(self):
         _, _, error = BotFeaturesHub._parse_bfrss_args("/bfrss -lob 26050a")
         assert error == "invalid_date"
+
+
+class TestBfrssHandler:
+    def test_sends_only_last_chunk_as_reply(self, hub):
+        hub.web_manager.fetch_rss.return_value = (["first", "middle", "last"], "HTML")
+        msg = make_message("/bfrss")
+
+        hub.rss_handler(msg)
+
+        assert hub.bot.send_message.call_args_list == [
+            call(msg.chat.id, "first", parse_mode="HTML"),
+            call(msg.chat.id, "middle", parse_mode="HTML"),
+        ]
+        hub.bot.reply_to.assert_called_once_with(msg, "last", parse_mode="HTML")
+
+    def test_single_chunk_is_sent_as_reply(self, hub):
+        hub.web_manager.fetch_rss.return_value = (["only"], "HTML")
+        msg = make_message("/bfrss -lob 260507")
+
+        hub.rss_handler(msg)
+
+        hub.web_manager.fetch_rss.assert_called_once_with("lob", "20260507")
+        hub.bot.send_message.assert_not_called()
+        hub.bot.reply_to.assert_called_once_with(msg, "only", parse_mode="HTML")
 
 
 class TestClearChatHandler:

--- a/tests/test_web_based.py
+++ b/tests/test_web_based.py
@@ -1,7 +1,5 @@
 import datetime
-import html
 import json
-import re
 import urllib.parse
 from unittest.mock import MagicMock, patch
 
@@ -14,12 +12,13 @@ from resources import strings
 from tests.conftest import make_message
 
 
-def _html_visible_text(text):
-    return html.unescape(re.sub(r"<[^>]+>", "", text))
-
-
 def _utf16_length(text):
     return len(text.encode("utf-16-le")) // 2
+
+
+def _utf16_slice(text, offset, length):
+    encoded = text.encode("utf-16-le")
+    return encoded[offset * 2 : (offset + length) * 2].decode("utf-16-le")
 
 
 class TestWebManagerInit:
@@ -303,14 +302,20 @@ class TestRssHandler:
 
         with patch.object(WebManager, "__init__", lambda self: None):
             wm = WebManager()
-            messages, parse_mode = wm.fetch_rss()
-            text = messages[0]
-            assert parse_mode == "HTML"
+            messages = wm.fetch_rss()
+            text, entities = messages[0]
             assert len(messages) == 1
             assert "THE HACKER NEWS" in text
             assert "Test Article" in text
-            assert "&lt;special&gt;" in text
-            assert "&amp;chars" in text
+            assert "Article with <special> &chars" in text
+            assert [entity.url for entity in entities] == [
+                "https://example.com",
+                "https://example.com/path?a=1&b=2",
+            ]
+            assert [_utf16_slice(text, entity.offset, entity.length) for entity in entities] == [
+                "Test Article",
+                "Article with <special> &chars",
+            ]
             mock_get.assert_called_once_with(
                 "http://test-server/feed/hn",
                 headers={"Authorization": "Bearer test_token"},
@@ -328,9 +333,8 @@ class TestRssHandler:
 
         with patch.object(WebManager, "__init__", lambda self: None):
             wm = WebManager()
-            messages, parse_mode = wm.fetch_rss(slug="lob")
-            text = messages[0]
-            assert parse_mode == "HTML"
+            messages = wm.fetch_rss(slug="lob")
+            text, _ = messages[0]
             assert "LOBSTERS" in text
             mock_get.assert_called_once_with(
                 "http://test-server/feed/lob",
@@ -367,18 +371,32 @@ class TestRssHandler:
 
         with patch.object(WebManager, "__init__", lambda self: None):
             wm = WebManager()
-            messages, parse_mode = wm.fetch_rss()
-            text = messages[0]
-            assert parse_mode == "HTML"
+            messages = wm.fetch_rss()
+            text, _ = messages[0]
             assert "오전" not in text
             assert "오후" not in text
+
+    @patch("modules.web_based.config.RSSF_URL", "http://test-server")
+    @patch("modules.web_based.config.RSSF_TOKEN", "test_token")
+    @patch("modules.web_based.requests.get")
+    def test_empty_entries_return_header_message(self, mock_get):
+        response = MagicMock()
+        response.text = json.dumps({**self._response_data, "entries": []})
+        mock_get.return_value = response
+
+        with patch.object(WebManager, "__init__", lambda self: None):
+            messages = WebManager().fetch_rss()
+
+        assert len(messages) == 1
+        text, entities = messages[0]
+        assert "THE HACKER NEWS" in text
+        assert entities == []
 
     def test_unknown_slug(self):
         with patch.object(WebManager, "__init__", lambda self: None):
             wm = WebManager()
-            messages, parse_mode = wm.fetch_rss(slug="xyz")
-            assert messages == [strings.bfrss_unknown_slug_msg]
-            assert parse_mode is None
+            messages = wm.fetch_rss(slug="xyz")
+            assert messages == [(strings.bfrss_unknown_slug_msg, [])]
 
     @patch("modules.web_based.config.RSSF_URL", "http://test-server")
     @patch("modules.web_based.config.RSSF_TOKEN", "test_token")
@@ -388,9 +406,8 @@ class TestRssHandler:
 
         with patch.object(WebManager, "__init__", lambda self: None):
             wm = WebManager()
-            messages, parse_mode = wm.fetch_rss()
-            assert messages == [strings.bfrss_error_msg]
-            assert parse_mode is None
+            messages = wm.fetch_rss()
+            assert messages == [(strings.bfrss_error_msg, [])]
 
     @patch("modules.web_based.config.RSSF_URL", "http://test-server")
     @patch("modules.web_based.config.RSSF_TOKEN", "test_token")
@@ -402,9 +419,8 @@ class TestRssHandler:
 
         with patch.object(WebManager, "__init__", lambda self: None):
             wm = WebManager()
-            messages, parse_mode = wm.fetch_rss()
-            assert messages == [strings.bfrss_error_msg]
-            assert parse_mode is None
+            messages = wm.fetch_rss()
+            assert messages == [(strings.bfrss_error_msg, [])]
             response.raise_for_status.assert_called_once()
 
     @patch("modules.web_based.config.RSSF_URL", "http://test-server")
@@ -423,24 +439,27 @@ class TestRssHandler:
         mock_get.return_value = response
 
         with patch.object(WebManager, "__init__", lambda self: None):
-            messages, parse_mode = WebManager().fetch_rss()
+            messages = WebManager().fetch_rss()
 
-        assert parse_mode == "HTML"
         assert len(messages) > 1
-        assert "THE HACKER NEWS" in messages[0]
-        assert all("THE HACKER NEWS" not in message for message in messages[1:])
-        assert sum(message.count("<a href=") for message in messages) == len(entries)
-        assert all(message.count("<a href=") == message.count("</a>") for message in messages)
-        assert all(_utf16_length(_html_visible_text(message)) <= BFRSS_MESSAGE_MAX_UTF16_LENGTH for message in messages)
+        assert "THE HACKER NEWS" in messages[0][0]
+        assert all("THE HACKER NEWS" not in text for text, _ in messages[1:])
+        assert sum(len(entities) for _, entities in messages) == len(entries)
+        assert all(_utf16_length(text) <= BFRSS_MESSAGE_MAX_UTF16_LENGTH for text, _ in messages)
 
-        combined = "\n".join(messages)
+        combined = "".join(text for text, _ in messages)
         for entry in entries:
-            assert html.escape(entry["title"]) in combined
+            assert entry["title"] in combined
+
+        expected_titles = {entry["link"]: entry["title"] for entry in entries}
+        for text, entities in messages:
+            for entity in entities:
+                assert _utf16_slice(text, entity.offset, entity.length) == expected_titles[entity.url]
 
     @patch("modules.web_based.config.RSSF_URL", "http://test-server")
     @patch("modules.web_based.config.RSSF_TOKEN", "test_token")
     @patch("modules.web_based.requests.get")
-    def test_oversized_single_title_is_split_without_breaking_html(self, mock_get):
+    def test_oversized_single_title_is_split_with_link_entities(self, mock_get):
         title = "😀" * 5000
         response = MagicMock()
         response.text = json.dumps(
@@ -452,10 +471,15 @@ class TestRssHandler:
         mock_get.return_value = response
 
         with patch.object(WebManager, "__init__", lambda self: None):
-            messages, parse_mode = WebManager().fetch_rss()
+            messages = WebManager().fetch_rss()
 
-        assert parse_mode == "HTML"
         assert len(messages) > 1
-        assert sum(message.count("😀") for message in messages) == len(title)
-        assert all(message.count("<a href=") == message.count("</a>") for message in messages)
-        assert all(_utf16_length(_html_visible_text(message)) <= BFRSS_MESSAGE_MAX_UTF16_LENGTH for message in messages)
+        assert sum(text.count("😀") for text, _ in messages) == len(title)
+        assert all(_utf16_length(text) <= BFRSS_MESSAGE_MAX_UTF16_LENGTH for text, _ in messages)
+
+        entities = [entity for _, chunk_entities in messages for entity in chunk_entities]
+        assert all(entity.url == "https://example.com/long" for entity in entities)
+        assert sum(entity.length for entity in entities) == _utf16_length(title)
+        for text, chunk_entities in messages:
+            for entity in chunk_entities:
+                assert set(_utf16_slice(text, entity.offset, entity.length)) == {"😀"}

--- a/tests/test_web_based.py
+++ b/tests/test_web_based.py
@@ -1,5 +1,7 @@
 import datetime
+import html
 import json
+import re
 import urllib.parse
 from unittest.mock import MagicMock, patch
 
@@ -7,9 +9,17 @@ import pytest
 import requests
 
 from modules.api_models import KakaoSearchDocument, KakaoSearchResponse
-from modules.web_based import WebManager
+from modules.web_based import BFRSS_MESSAGE_MAX_UTF16_LENGTH, WebManager
 from resources import strings
 from tests.conftest import make_message
+
+
+def _html_visible_text(text):
+    return html.unescape(re.sub(r"<[^>]+>", "", text))
+
+
+def _utf16_length(text):
+    return len(text.encode("utf-16-le")) // 2
 
 
 class TestWebManagerInit:
@@ -293,8 +303,10 @@ class TestRssHandler:
 
         with patch.object(WebManager, "__init__", lambda self: None):
             wm = WebManager()
-            text, parse_mode = wm.fetch_rss()
+            messages, parse_mode = wm.fetch_rss()
+            text = messages[0]
             assert parse_mode == "HTML"
+            assert len(messages) == 1
             assert "THE HACKER NEWS" in text
             assert "Test Article" in text
             assert "&lt;special&gt;" in text
@@ -316,7 +328,8 @@ class TestRssHandler:
 
         with patch.object(WebManager, "__init__", lambda self: None):
             wm = WebManager()
-            text, parse_mode = wm.fetch_rss(slug="lob")
+            messages, parse_mode = wm.fetch_rss(slug="lob")
+            text = messages[0]
             assert parse_mode == "HTML"
             assert "LOBSTERS" in text
             mock_get.assert_called_once_with(
@@ -354,7 +367,8 @@ class TestRssHandler:
 
         with patch.object(WebManager, "__init__", lambda self: None):
             wm = WebManager()
-            text, parse_mode = wm.fetch_rss()
+            messages, parse_mode = wm.fetch_rss()
+            text = messages[0]
             assert parse_mode == "HTML"
             assert "오전" not in text
             assert "오후" not in text
@@ -362,8 +376,8 @@ class TestRssHandler:
     def test_unknown_slug(self):
         with patch.object(WebManager, "__init__", lambda self: None):
             wm = WebManager()
-            text, parse_mode = wm.fetch_rss(slug="xyz")
-            assert text == strings.bfrss_unknown_slug_msg
+            messages, parse_mode = wm.fetch_rss(slug="xyz")
+            assert messages == [strings.bfrss_unknown_slug_msg]
             assert parse_mode is None
 
     @patch("modules.web_based.config.RSSF_URL", "http://test-server")
@@ -374,8 +388,8 @@ class TestRssHandler:
 
         with patch.object(WebManager, "__init__", lambda self: None):
             wm = WebManager()
-            text, parse_mode = wm.fetch_rss()
-            assert text == strings.bfrss_error_msg
+            messages, parse_mode = wm.fetch_rss()
+            assert messages == [strings.bfrss_error_msg]
             assert parse_mode is None
 
     @patch("modules.web_based.config.RSSF_URL", "http://test-server")
@@ -388,7 +402,60 @@ class TestRssHandler:
 
         with patch.object(WebManager, "__init__", lambda self: None):
             wm = WebManager()
-            text, parse_mode = wm.fetch_rss()
-            assert text == strings.bfrss_error_msg
+            messages, parse_mode = wm.fetch_rss()
+            assert messages == [strings.bfrss_error_msg]
             assert parse_mode is None
             response.raise_for_status.assert_called_once()
+
+    @patch("modules.web_based.config.RSSF_URL", "http://test-server")
+    @patch("modules.web_based.config.RSSF_TOKEN", "test_token")
+    @patch("modules.web_based.requests.get")
+    def test_many_entries_are_split_at_article_boundaries(self, mock_get):
+        entries = [
+            {
+                "title": f"번역 기사 {index} " + "긴 문장 내용 " * 30,
+                "link": f"https://example.com/articles/{index}?a=1&b=2",
+            }
+            for index in range(80)
+        ]
+        response = MagicMock()
+        response.text = json.dumps({**self._response_data, "entries": entries})
+        mock_get.return_value = response
+
+        with patch.object(WebManager, "__init__", lambda self: None):
+            messages, parse_mode = WebManager().fetch_rss()
+
+        assert parse_mode == "HTML"
+        assert len(messages) > 1
+        assert "THE HACKER NEWS" in messages[0]
+        assert all("THE HACKER NEWS" not in message for message in messages[1:])
+        assert sum(message.count("<a href=") for message in messages) == len(entries)
+        assert all(message.count("<a href=") == message.count("</a>") for message in messages)
+        assert all(_utf16_length(_html_visible_text(message)) <= BFRSS_MESSAGE_MAX_UTF16_LENGTH for message in messages)
+
+        combined = "\n".join(messages)
+        for entry in entries:
+            assert html.escape(entry["title"]) in combined
+
+    @patch("modules.web_based.config.RSSF_URL", "http://test-server")
+    @patch("modules.web_based.config.RSSF_TOKEN", "test_token")
+    @patch("modules.web_based.requests.get")
+    def test_oversized_single_title_is_split_without_breaking_html(self, mock_get):
+        title = "😀" * 5000
+        response = MagicMock()
+        response.text = json.dumps(
+            {
+                **self._response_data,
+                "entries": [{"title": title, "link": "https://example.com/long"}],
+            }
+        )
+        mock_get.return_value = response
+
+        with patch.object(WebManager, "__init__", lambda self: None):
+            messages, parse_mode = WebManager().fetch_rss()
+
+        assert parse_mode == "HTML"
+        assert len(messages) > 1
+        assert sum(message.count("😀") for message in messages) == len(title)
+        assert all(message.count("<a href=") == message.count("</a>") for message in messages)
+        assert all(_utf16_length(_html_visible_text(message)) <= BFRSS_MESSAGE_MAX_UTF16_LENGTH for message in messages)


### PR DESCRIPTION
## Summary
- 길이가 긴 BFRSS 응답을 Telegram 메시지 제한에 맞춰 여러 메시지로 분할합니다.
- Telegram text_link entity 모듈을 사용해 분할 후에도 기사 링크를 유지하게끔 바꿨습니다.
- 마지막 직전까지의 분할된 메시지는 일반 메시지로 전송하고 마지막 메시지만 원본 명령에 reply_to로 응답합니다.

## Changes
### BFRSS 메시지 처리
- HTML 기반 RSS 항목을 plain text와 MessageEntity 기반 구조로 변경
- UTF-16 기준 4090자 단위 제한에 맞춰 split_entities()로 메시지 분할
- 기존 외부 API 요청, JSON 파싱 및 handler 예외 처리 방식 유지
- 다중 메시지, 빈 기사 목록, entity offset, 초장문 이모지 제목 테스트 추가

## Test plan
- [x] Ruff lint 검사 통과
- [x] Ruff format 검사 통과
- [x] 전체 테스트 618개 통과
- [x] 테스트 coverage 94.93%
- [ ] 로컬 봇 실행은 수행하지 않았음