### PR TITLE
Replace commute ForceReply flow with command parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ modules/
   api_models.py              # 외부 API pydantic 응답 모델
   calculator.py              # 수식 계산기
   commute.py                 # 출퇴근 일정 저장과 남은 시간 계산
-  commute_manager.py         # 출퇴근 일정 관리 UI와 callback 처리
+  commute_manager.py         # 출퇴근 일정 명령과 남은 시간 응답 처리
   database.py                # peewee ORM 모델과 SQLite 초기화
   laftel.py                  # Laftel 편성표, 랭킹, 검색
   spotify.py                 # Spotify 곡 검색과 상세 카드
@@ -119,8 +119,9 @@ docker compose --env-file .deploy.env up -d
 - 현재 위치 정보: 텔레그램 위치 메시지에 주소, 좌표, 날씨 응답
 - D-day: `/dday YYYY M D`
 - 계산기: `/calc sin ( pi / 2 )`
-- 출퇴근 상태 확인: `출근`·`퇴근` 키워드로 현재 근무 상태 또는 다음 출근·퇴근까지 남은 시간 확인
-- 출퇴근 일정 관리: `/commute`로 요일별 출퇴근 일정 등록·조회·삭제
+- 출퇴근 상태 확인: `출근 시간`·`퇴근 시간` 키워드로 현재 근무 상태 또는 다음 출근·퇴근까지 남은 시간 확인
+- 출퇴근 일정 관리: `/commute`로 조회, `/commute 등록 월화 9:00 18:00`으로 등록,
+  `/commute 삭제 월화`로 일부 삭제, `/commute 전체삭제`로 전체 삭제
 - 검색: `/search`
 - 나무위키 검색: `/namu`
 - AI 질문: `/ask`, 이미지 caption 또는 사진 reply 지원

--- a/bin/handlers.py
+++ b/bin/handlers.py
@@ -65,9 +65,6 @@ def register_handlers(bot, hub, logger):
             if BotFeaturesHub.is_spotify_callback(query.data):
                 hub.handle_spotify_callback(query)
                 return
-            if BotFeaturesHub.is_commute_callback(query.data):
-                hub.handle_commute_callback(query)
-                return
             result = QUERY_STRINGS.get(query.data)
             if result is not None:
                 bot.send_chat_action(query.message.chat.id, "typing")
@@ -168,7 +165,7 @@ def register_handlers(bot, hub, logger):
     @bot.message_handler(commands=["commute"])
     @safe_handler
     def handle_commute(message):
-        hub.commute_menu_handler(message)
+        hub.commute_handler(message)
 
     # Admin commands
     @bot.message_handler(commands=["allow_chat"])
@@ -217,21 +214,6 @@ def register_handlers(bot, hub, logger):
     @safe_handler
     def handle_laftel_search_reply(message):
         hub.laftel.handle_search_reply(message)
-
-    # ForceReply handler for commute schedule input
-    def is_commute_reply(message):
-        if not message.reply_to_message:
-            return False
-
-        return message.reply_to_message.text in {
-            strings.commute_set_input_msg,
-            strings.commute_delete_input_msg,
-        }
-
-    @bot.message_handler(func=is_commute_reply)
-    @safe_handler
-    def handle_commute_reply(message):
-        hub.handle_commute_reply(message)
 
     # Ordinary message
     @bot.message_handler(content_types=["text"])

--- a/modules/commute.py
+++ b/modules/commute.py
@@ -7,14 +7,13 @@ DAYS_PER_WEEK = 7
 MINUTES_PER_DAY = HOURS_PER_DAY * MINUTES_PER_HOUR
 MINUTES_PER_WEEK = DAYS_PER_WEEK * MINUTES_PER_DAY
 END_OF_DAY_TIME = "24:00"
-
 VALIDATION_ERROR_MESSAGES = {
     "hour_out_of_range": "hour must be between 0 and 23",
     "minute_out_of_range": "minute must be between 0 and 59",
     "invalid_weekday": "invalid weekday",
     "empty_weekday": "weekday cannot be empty",
     "same_start_and_end": "start and end time must be different",
-    "negative_minutes": "minutes must not be negative",
+    "negative_minutes": "minutes cannot be negative",
 }
 
 WEEKDAY_MAP = {name: index for index, name in enumerate(strings.commute_weekday_names)}

--- a/modules/commute.py
+++ b/modules/commute.py
@@ -1,3 +1,5 @@
+import re
+
 from modules.database import CommuteSchedule, db
 from resources import strings
 
@@ -7,7 +9,9 @@ DAYS_PER_WEEK = 7
 MINUTES_PER_DAY = HOURS_PER_DAY * MINUTES_PER_HOUR
 MINUTES_PER_WEEK = DAYS_PER_WEEK * MINUTES_PER_DAY
 END_OF_DAY_TIME = "24:00"
+TIME_FORMAT_PATTERN = re.compile(r"[0-9]{1,2}:[0-9]{2}")
 VALIDATION_ERROR_MESSAGES = {
+    "invalid_time_format": "time must use H:mm or HH:mm format",
     "hour_out_of_range": "hour must be between 0 and 23",
     "minute_out_of_range": "minute must be between 0 and 59",
     "invalid_weekday": "invalid weekday",
@@ -20,6 +24,9 @@ WEEKDAY_MAP = {name: index for index, name in enumerate(strings.commute_weekday_
 
 
 def parse_time_to_minutes(time_text):
+    if TIME_FORMAT_PATTERN.fullmatch(time_text) is None:
+        raise ValueError(VALIDATION_ERROR_MESSAGES["invalid_time_format"])
+
     hour_text, minute_text = time_text.split(":")
     hour = int(hour_text)
     minute = int(minute_text)

--- a/modules/commute_manager.py
+++ b/modules/commute_manager.py
@@ -1,8 +1,4 @@
 import datetime
-import threading
-import time
-
-import telebot
 
 from config import config
 from modules.commute import (
@@ -17,66 +13,36 @@ from modules.commute import (
 )
 from resources import strings
 
-CALLBACK_PREFIXES = frozenset({"commute", "commute_clear"})
-INPUT_TIMEOUT_SECONDS = 300
-
 
 class CommuteManager:
     def __init__(self, bot):
         self.bot = bot
-        self._pending_inputs = {}
-        self._pending_inputs_lock = threading.Lock()
 
-    @staticmethod
-    def is_commute_callback(data):
-        return bool(data and ":" in data and data.split(":", 1)[0] in CALLBACK_PREFIXES)
+    def handle_command(self, message):
+        parts = (message.text or "").split()
+        arguments = parts[1:]
 
-    def handle_commute_callback(self, call):
-        parts = call.data.split(":")
-        if len(parts) != 3:
+        if not arguments:
+            self.show_menu(message)
             return
 
-        action, value, owner_id_text = parts
-        try:
-            owner_id = int(owner_id_text)
-        except ValueError:
-            return
+        action = arguments[0]
+        action_arguments = arguments[1:]
 
-        if call.from_user.id != owner_id:
-            return
-
-        if action == "commute":
-            if value in {"set", "delete"}:
-                self._request_input(call, value)
-            elif value == "clear":
-                self._show_clear_confirmation(call, owner_id)
-            elif value == "cancel":
-                self.bot.edit_message_text(
-                    strings.commute_menu_cancelled_msg,
-                    call.message.chat.id,
-                    call.message.message_id,
-                )
-            return
-
-        if action == "commute_clear":
-            if value == "confirm":
-                self._clear_schedules(call)
-            elif value == "cancel":
-                self.bot.edit_message_text(
-                    strings.commute_clear_cancelled_msg,
-                    call.message.chat.id,
-                    call.message.message_id,
-                )
+        if action == strings.commute_register_action:
+            self._save_schedule_from_arguments(message, action_arguments)
+        elif action == strings.commute_delete_action:
+            self._delete_schedules_from_arguments(message, action_arguments)
+        elif action == strings.commute_delete_all_action:
+            self._delete_all_schedules_from_arguments(message, action_arguments)
+        else:
+            self.bot.reply_to(message, strings.commute_command_error_msg)
 
     def show_menu(self, message):
         schedule_text = self._build_schedule_text(message.from_user.id)
         menu_text = strings.commute_menu_msg.format(schedule=schedule_text)
 
-        self.bot.reply_to(
-            message,
-            menu_text,
-            reply_markup=self._build_menu_keyboard(message.from_user.id),
-        )
+        self.bot.reply_to(message, menu_text)
 
     @staticmethod
     def get_current_commute_time():
@@ -136,65 +102,12 @@ class CommuteManager:
             ),
         )
 
-    def handle_input_reply(self, message):
-        reply_to = message.reply_to_message
-        if not reply_to:
-            return
-
-        pending_key = (message.chat.id, reply_to.message_id)
-        with self._pending_inputs_lock:
-            pending = self._pending_inputs.get(pending_key)
-            if pending is None:
-                return
-
-            user_id, action, created_at = pending
-            if message.from_user.id != user_id:
-                return
-
-            del self._pending_inputs[pending_key]
-
-        if time.time() - created_at > INPUT_TIMEOUT_SECONDS:
-            self.bot.reply_to(message, strings.commute_input_expired_msg)
-            return
-
-        if action == "set":
-            self._save_schedule_from_reply(message)
-        elif action == "delete":
-            self._delete_schedules_from_reply(message)
-
-    def _request_input(self, call, action):
-        self._cleanup_expired_inputs()
-        prompt = strings.commute_set_input_msg if action == "set" else strings.commute_delete_input_msg
-        original_message = getattr(call.message, "reply_to_message", None)
-        original_message_id = getattr(original_message, "message_id", None)
-        self.bot.edit_message_reply_markup(
-            call.message.chat.id,
-            call.message.message_id,
-            reply_markup=None,
-        )
-        sent = self.bot.send_message(
-            call.message.chat.id,
-            prompt,
-            reply_to_message_id=original_message_id,
-            reply_markup=telebot.types.ForceReply(
-                selective=original_message_id is not None,
-            ),
-        )
-        pending_key = (call.message.chat.id, sent.message_id)
-        with self._pending_inputs_lock:
-            self._pending_inputs[pending_key] = (
-                call.from_user.id,
-                action,
-                time.time(),
-            )
-
-    def _save_schedule_from_reply(self, message):
-        parts = (message.text or "").split()
-        if len(parts) != 3:
+    def _save_schedule_from_arguments(self, message, arguments):
+        if len(arguments) != 3:
             self.bot.reply_to(message, strings.commute_set_error_msg)
             return
 
-        weekday_text, start_time_text, end_time_text = parts
+        weekday_text, start_time_text, end_time_text = arguments
         try:
             count = save_schedule(
                 message.from_user.id,
@@ -211,14 +124,13 @@ class CommuteManager:
             strings.commute_set_success_msg.format(count=count),
         )
 
-    def _delete_schedules_from_reply(self, message):
-        parts = (message.text or "").split()
-        if len(parts) != 1:
+    def _delete_schedules_from_arguments(self, message, arguments):
+        if len(arguments) != 1:
             self.bot.reply_to(message, strings.commute_delete_error_msg)
             return
 
         try:
-            count = delete_schedules(message.from_user.id, parts[0])
+            count = delete_schedules(message.from_user.id, arguments[0])
         except ValueError:
             self.bot.reply_to(message, strings.commute_delete_error_msg)
             return
@@ -232,42 +144,14 @@ class CommuteManager:
             strings.commute_delete_success_msg.format(count=count),
         )
 
-    def _show_clear_confirmation(self, call, owner_id):
-        keyboard = telebot.types.InlineKeyboardMarkup()
-        keyboard.row(
-            telebot.types.InlineKeyboardButton(
-                strings.commute_confirm_btn,
-                callback_data=f"commute_clear:confirm:{owner_id}",
-            ),
-            telebot.types.InlineKeyboardButton(
-                strings.commute_cancel_btn,
-                callback_data=f"commute_clear:cancel:{owner_id}",
-            ),
-        )
-        self.bot.edit_message_text(
-            strings.commute_clear_confirm_msg,
-            call.message.chat.id,
-            call.message.message_id,
-            reply_markup=keyboard,
-        )
+    def _delete_all_schedules_from_arguments(self, message, arguments):
+        if arguments:
+            self.bot.reply_to(message, strings.commute_command_error_msg)
+            return
 
-    def _clear_schedules(self, call):
-        count = delete_all_schedules(call.from_user.id)
-        result = strings.commute_clear_success_msg if count else strings.commute_delete_missing_msg
-        self.bot.edit_message_text(
-            result,
-            call.message.chat.id,
-            call.message.message_id,
-        )
-
-    def _cleanup_expired_inputs(self):
-        now = time.time()
-        with self._pending_inputs_lock:
-            self._pending_inputs = {
-                pending_key: pending
-                for pending_key, pending in self._pending_inputs.items()
-                if now - pending[2] <= INPUT_TIMEOUT_SECONDS
-            }
+        count = delete_all_schedules(message.from_user.id)
+        result = strings.commute_delete_all_success_msg if count else strings.commute_delete_missing_msg
+        self.bot.reply_to(message, result)
 
     @staticmethod
     def _build_schedule_text(user_id):
@@ -290,29 +174,3 @@ class CommuteManager:
         hour, minute = divmod(total_minutes, MINUTES_PER_HOUR)
 
         return f"{hour:02d}:{minute:02d}"
-
-    @staticmethod
-    def _build_menu_keyboard(owner_id):
-        keyboard = telebot.types.InlineKeyboardMarkup()
-        keyboard.row(
-            telebot.types.InlineKeyboardButton(
-                strings.commute_set_btn,
-                callback_data=f"commute:set:{owner_id}",
-            ),
-            telebot.types.InlineKeyboardButton(
-                strings.commute_delete_btn,
-                callback_data=f"commute:delete:{owner_id}",
-            ),
-        )
-        keyboard.row(
-            telebot.types.InlineKeyboardButton(
-                strings.commute_clear_btn,
-                callback_data=f"commute:clear:{owner_id}",
-            ),
-            telebot.types.InlineKeyboardButton(
-                strings.commute_close_btn,
-                callback_data=f"commute:cancel:{owner_id}",
-            ),
-        )
-
-        return keyboard

--- a/modules/features_hub.py
+++ b/modules/features_hub.py
@@ -33,10 +33,6 @@ class BotFeaturesHub:
     def is_spotify_callback(data):
         return SpotifyService.is_spotify_callback(data)
 
-    @staticmethod
-    def is_commute_callback(data):
-        return CommuteManager.is_commute_callback(data)
-
     # init
     def __init__(self, bot):
         self.bot = bot
@@ -65,9 +61,6 @@ class BotFeaturesHub:
     def handle_spotify_callback(self, call):
         self.spotify.handle_spotify_callback(call)
 
-    def handle_commute_callback(self, call):
-        self.commute.handle_commute_callback(call)
-
     def allow_chat_handler(self, message):
         self.admin.allow_chat_handler(message)
 
@@ -80,11 +73,8 @@ class BotFeaturesHub:
     def handle_prompt_reply(self, message):
         self.admin.handle_prompt_reply(message)
 
-    def commute_menu_handler(self, message):
-        self.commute.show_menu(message)
-
-    def handle_commute_reply(self, message):
-        self.commute.handle_input_reply(message)
+    def commute_handler(self, message):
+        self.commute.handle_command(message)
 
     # --- Features ---
 

--- a/resources/strings.py
+++ b/resources/strings.py
@@ -97,30 +97,30 @@ magic_conch_keywords = ("마법의 소라고둥", "마법의 소라고동")
 commute_start_keywords = ("출근",)
 commute_end_keywords = ("퇴근",)
 commute_time_keywords = ("시간",)
+commute_register_action = "등록"
+commute_delete_action = "삭제"
+commute_delete_all_action = "전체삭제"
 
 # commute messages
 commute_weekday_names = ("월", "화", "수", "목", "금", "토", "일")
-commute_menu_msg = "출퇴근 일정 관리\n\n{schedule}"
-commute_schedule_empty_msg = "등록된 일정이 없습니다."
-commute_schedule_item_msg = "{weekday} {start_time}~{end_time}"
-commute_set_btn = "일정 등록"
-commute_delete_btn = "일부 삭제"
-commute_clear_btn = "전체 삭제"
-commute_close_btn = "닫기"
-commute_menu_cancelled_msg = "취소되었습니다."
-commute_confirm_btn = "삭제"
-commute_cancel_btn = "취소"
-commute_set_input_msg = "등록할 요일과 출퇴근 시간을 입력해 주세요.\n예: 월화수목금 09:00 18:00"
-commute_delete_input_msg = "삭제할 요일을 입력해 주세요.\n예: 월화"
+commute_menu_msg = (
+    "출퇴근 일정 관리\n\n"
+    "[현재 일정]\n"
+    "{schedule}\n\n"
+    "[사용법]\n"
+    "• /commute 등록 월화 9:00 18:00\n"
+    "• /commute 삭제 월화\n"
+    "• /commute 전체삭제"
+)
+commute_schedule_empty_msg = "• 없음"
+commute_schedule_item_msg = "• {weekday} {start_time}~{end_time}"
+commute_command_error_msg = "출퇴근 일정 관리 명령어가 올바르지 않습니다.\n/commute에서 사용법을 확인해 주세요."
 commute_set_error_msg = "일정 등록 형식이 올바르지 않습니다.\n/commute에서 다시 시도해 주세요."
 commute_delete_error_msg = "삭제할 요일 형식이 올바르지 않습니다.\n/commute에서 다시 시도해 주세요."
-commute_clear_confirm_msg = "등록된 출퇴근 일정을 모두 삭제할까요?"
-commute_clear_cancelled_msg = "출퇴근 일정 전체 삭제를 취소했습니다."
-commute_input_expired_msg = "입력 시간이 만료되었습니다. /commute에서 다시 시도해 주세요."
 
 commute_set_success_msg = "{count}개 요일의 출퇴근 일정을 등록했습니다."
 commute_delete_success_msg = "{count}개 요일의 출퇴근 일정을 삭제했습니다."
-commute_clear_success_msg = "등록된 출퇴근 일정을 모두 삭제했습니다."
+commute_delete_all_success_msg = "등록된 출퇴근 일정을 모두 삭제했습니다."
 commute_delete_missing_msg = "삭제할 출퇴근 일정이 없습니다."
 commute_working_msg = "현재 근무 중입니다."
 commute_not_working_msg = "현재 근무 시간이 아닙니다."

--- a/tests/test_commute.py
+++ b/tests/test_commute.py
@@ -93,6 +93,7 @@ class TestSaveSchedule:
         assert CommuteSchedule.select().count() == 0
 
     def test_rolls_back_all_weekdays_when_save_fails(self, monkeypatch):
+        save_schedule(123, "월", "09:00", "18:00")
         original_replace = CommuteSchedule.replace
         call_count = 0
 
@@ -108,9 +109,13 @@ class TestSaveSchedule:
         monkeypatch.setattr(CommuteSchedule, "replace", replace_with_failure)
 
         with pytest.raises(RuntimeError, match="simulated database failure"):
-            save_schedule(123, "월화", "09:00", "18:00")
+            save_schedule(123, "월화", "10:00", "19:00")
 
-        assert CommuteSchedule.select().count() == 0
+        schedules = list(CommuteSchedule.select())
+        assert len(schedules) == 1
+        assert schedules[0].weekday == 0
+        assert schedules[0].start_time_minutes == 9 * 60
+        assert schedules[0].end_time_minutes == 18 * 60
 
 
 class TestGetSchedules:

--- a/tests/test_commute.py
+++ b/tests/test_commute.py
@@ -19,8 +19,17 @@ from modules.database import CommuteSchedule
 
 class TestParseTime:
     def test_valid_time(self):
+        assert parse_time_to_minutes("9:00") == 540
         assert parse_time_to_minutes("09:00") == 540
         assert parse_time_to_minutes("18:30") == 1110
+
+    @pytest.mark.parametrize(
+        "time_text",
+        ("9:0", "9:5", "009:00", "09:000", "+9:00", "09:+00"),
+    )
+    def test_invalid_time_format(self, time_text):
+        with pytest.raises(ValueError):
+            parse_time_to_minutes(time_text)
 
     def test_invalid_hour(self):
         with pytest.raises(ValueError):

--- a/tests/test_commute_manager.py
+++ b/tests/test_commute_manager.py
@@ -1,5 +1,3 @@
-import time
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
@@ -13,29 +11,19 @@ from tests.conftest import make_message
 
 
 class TestCommuteMenu:
-    def test_shows_empty_schedule_and_menu_buttons(self):
+    def test_shows_empty_schedule_without_menu_buttons(self):
         bot = MagicMock()
         manager = CommuteManager(bot)
         message = make_message("/commute", user_id=123)
 
         manager.show_menu(message)
 
-        bot.reply_to.assert_called_once()
-        args, kwargs = bot.reply_to.call_args
-        assert args == (
+        bot.reply_to.assert_called_once_with(
             message,
             strings.commute_menu_msg.format(
                 schedule=strings.commute_schedule_empty_msg,
             ),
         )
-
-        callback_data = [button.callback_data for row in kwargs["reply_markup"].keyboard for button in row]
-        assert callback_data == [
-            "commute:set:123",
-            "commute:delete:123",
-            "commute:clear:123",
-            "commute:cancel:123",
-        ]
 
     def test_shows_user_schedules_in_readable_format(self):
         save_schedule(123, "월화", "09:00", "18:00")
@@ -49,275 +37,132 @@ class TestCommuteMenu:
 
         expected_schedule = "\n".join(
             (
-                "월 09:00~18:00",
-                "화 09:00~18:00",
-                "금 22:00~07:00",
+                "• 월 09:00~18:00",
+                "• 화 09:00~18:00",
+                "• 금 22:00~07:00",
             )
         )
         bot.reply_to.assert_called_once_with(
             message,
             strings.commute_menu_msg.format(schedule=expected_schedule),
-            reply_markup=bot.reply_to.call_args.kwargs["reply_markup"],
         )
 
 
-class TestCommuteCallbacks:
-    @staticmethod
-    def make_callback(data, user_id=123, chat_id=1, message_id=10):
-        call = MagicMock()
-        call.data = f"{data}:{user_id}" if data.count(":") == 1 else data
-        call.from_user.id = user_id
-        call.message.chat.id = chat_id
-        call.message.message_id = message_id
-        original_message = make_message("/commute", user_id=user_id, chat_id=chat_id)
-        original_message.message_id = message_id - 1
-        call.message.reply_to_message = original_message
-        return call
+class TestCommuteCommands:
+    def test_command_without_action_shows_menu(self):
+        manager = CommuteManager(MagicMock())
+        manager.show_menu = MagicMock()
+        message = make_message("/commute", user_id=123)
 
-    def test_set_button_requests_input_and_saves_reply(self):
+        manager.handle_command(message)
+
+        manager.show_menu.assert_called_once_with(message)
+
+    def test_registers_schedule(self):
         bot = MagicMock()
-        prompt_message = MagicMock()
-        prompt_message.message_id = 99
-        bot.send_message.return_value = prompt_message
         manager = CommuteManager(bot)
-        call = self.make_callback("commute:set")
+        message = make_message("/commute 등록 월화 9:00 18:00", user_id=123)
 
-        manager.handle_commute_callback(call)
+        manager.handle_command(message)
 
-        bot.send_message.assert_called_once()
-        assert bot.send_message.call_args.args[:2] == (
-            call.message.chat.id,
-            strings.commute_set_input_msg,
-        )
-        assert bot.send_message.call_args.kwargs["reply_to_message_id"] == call.message.reply_to_message.message_id
-        assert bot.send_message.call_args.kwargs["reply_markup"].selective is True
-
-        reply = make_message("월화 09:00 18:00", user_id=123)
-        reply.reply_to_message = prompt_message
-        manager.handle_input_reply(reply)
-
-        schedules = manager._build_schedule_text(123)
-        assert schedules == "월 09:00~18:00\n화 09:00~18:00"
-        bot.reply_to.assert_called_once_with(
-            reply,
-            strings.commute_set_success_msg.format(count=2),
-        )
-
-    def test_set_prompt_falls_back_to_non_selective_force_reply_without_original_message(self):
-        bot = MagicMock()
-        prompt_message = MagicMock()
-        prompt_message.message_id = 99
-        bot.send_message.return_value = prompt_message
-        manager = CommuteManager(bot)
-        call = self.make_callback("commute:set")
-        call.message.reply_to_message = None
-
-        manager.handle_commute_callback(call)
-
-        assert bot.send_message.call_args.kwargs["reply_to_message_id"] is None
-        assert bot.send_message.call_args.kwargs["reply_markup"].selective is False
-
-    def test_delete_button_requests_input_and_deletes_reply(self):
-        save_schedule(123, "월화", "09:00", "18:00")
-        bot = MagicMock()
-        prompt_message = MagicMock()
-        prompt_message.message_id = 99
-        bot.send_message.return_value = prompt_message
-        manager = CommuteManager(bot)
-        call = self.make_callback("commute:delete")
-
-        manager.handle_commute_callback(call)
-
-        assert bot.send_message.call_args.args[:2] == (
-            call.message.chat.id,
-            strings.commute_delete_input_msg,
-        )
-
-        reply = make_message("월", user_id=123)
-        reply.reply_to_message = prompt_message
-        manager.handle_input_reply(reply)
-
-        assert manager._build_schedule_text(123) == "화 09:00~18:00"
-        bot.reply_to.assert_called_once_with(
-            reply,
-            strings.commute_delete_success_msg.format(count=1),
-        )
+        assert manager._build_schedule_text(123) == "• 월 09:00~18:00\n• 화 09:00~18:00"
+        bot.reply_to.assert_called_once_with(message, strings.commute_set_success_msg.format(count=2))
 
     @pytest.mark.parametrize(
         "text",
         (
-            "월 09:00",
-            "월 잘못된시간 18:00",
+            "/commute 등록",
+            "/commute 등록 월 09:00",
+            "/commute 등록 월 잘못된시간 18:00",
+            "/commute 등록 잘못된요일 09:00 18:00",
+            "/commute 등록 월 09:00 09:00",
         ),
     )
-    def test_invalid_set_reply_shows_set_error(self, text):
+    def test_invalid_register_command_shows_error(self, text):
         bot = MagicMock()
         manager = CommuteManager(bot)
         message = make_message(text, user_id=123)
 
-        manager._save_schedule_from_reply(message)
+        manager.handle_command(message)
 
+        assert manager._build_schedule_text(123) == strings.commute_schedule_empty_msg
         bot.reply_to.assert_called_once_with(message, strings.commute_set_error_msg)
 
+    def test_deletes_selected_schedules(self):
+        save_schedule(123, "월화수", "09:00", "18:00")
+        bot = MagicMock()
+        manager = CommuteManager(bot)
+        message = make_message("/commute 삭제 월화", user_id=123)
+
+        manager.handle_command(message)
+
+        assert manager._build_schedule_text(123) == "• 수 09:00~18:00"
+        bot.reply_to.assert_called_once_with(message, strings.commute_delete_success_msg.format(count=2))
+
     @pytest.mark.parametrize(
         "text",
         (
-            "월 화",
-            "잘못된요일",
+            "/commute 삭제",
+            "/commute 삭제 잘못된요일",
         ),
     )
-    def test_invalid_delete_reply_shows_delete_error(self, text):
+    def test_invalid_delete_command_shows_error(self, text):
         bot = MagicMock()
         manager = CommuteManager(bot)
         message = make_message(text, user_id=123)
 
-        manager._delete_schedules_from_reply(message)
+        manager.handle_command(message)
 
         bot.reply_to.assert_called_once_with(message, strings.commute_delete_error_msg)
 
-    def test_clear_button_asks_for_confirmation_and_clears_schedule(self):
+    def test_delete_missing_schedule_shows_error(self):
+        bot = MagicMock()
+        manager = CommuteManager(bot)
+        message = make_message("/commute 삭제 월", user_id=123)
+
+        manager.handle_command(message)
+
+        bot.reply_to.assert_called_once_with(message, strings.commute_delete_missing_msg)
+
+    def test_deletes_all_schedules(self):
         save_schedule(123, "월화", "09:00", "18:00")
         bot = MagicMock()
         manager = CommuteManager(bot)
-        call = self.make_callback("commute:clear")
+        message = make_message("/commute 전체삭제", user_id=123)
 
-        manager.handle_commute_callback(call)
-
-        args, kwargs = bot.edit_message_text.call_args
-        assert args == (
-            strings.commute_clear_confirm_msg,
-            call.message.chat.id,
-            call.message.message_id,
-        )
-        callback_data = [button.callback_data for row in kwargs["reply_markup"].keyboard for button in row]
-        assert callback_data == [
-            "commute_clear:confirm:123",
-            "commute_clear:cancel:123",
-        ]
-
-        confirm_call = self.make_callback("commute_clear:confirm")
-        manager.handle_commute_callback(confirm_call)
+        manager.handle_command(message)
 
         assert manager._build_schedule_text(123) == strings.commute_schedule_empty_msg
-        bot.edit_message_text.assert_called_with(
-            strings.commute_clear_success_msg,
-            confirm_call.message.chat.id,
-            confirm_call.message.message_id,
-        )
+        bot.reply_to.assert_called_once_with(message, strings.commute_delete_all_success_msg)
 
-    def test_clear_cancel_keeps_schedule(self):
+    def test_delete_all_without_schedules_shows_error(self):
+        bot = MagicMock()
+        manager = CommuteManager(bot)
+        message = make_message("/commute 전체삭제", user_id=123)
+
+        manager.handle_command(message)
+
+        bot.reply_to.assert_called_once_with(message, strings.commute_delete_missing_msg)
+
+    def test_delete_all_with_extra_argument_does_not_delete(self):
         save_schedule(123, "월", "09:00", "18:00")
         bot = MagicMock()
         manager = CommuteManager(bot)
-        call = self.make_callback("commute_clear:cancel")
+        message = make_message("/commute 전체삭제 월", user_id=123)
 
-        manager.handle_commute_callback(call)
+        manager.handle_command(message)
 
-        assert manager._build_schedule_text(123) == "월 09:00~18:00"
-        bot.edit_message_text.assert_called_once_with(
-            strings.commute_clear_cancelled_msg,
-            call.message.chat.id,
-            call.message.message_id,
-        )
+        assert manager._build_schedule_text(123) == "• 월 09:00~18:00"
+        bot.reply_to.assert_called_once_with(message, strings.commute_command_error_msg)
 
-    def test_close_button_closes_menu(self):
+    def test_unknown_action_shows_error(self):
         bot = MagicMock()
         manager = CommuteManager(bot)
-        call = self.make_callback("commute:cancel")
+        message = make_message("/commute 알수없음", user_id=123)
 
-        manager.handle_commute_callback(call)
+        manager.handle_command(message)
 
-        bot.edit_message_text.assert_called_once_with(
-            strings.commute_menu_cancelled_msg,
-            call.message.chat.id,
-            call.message.message_id,
-        )
-
-    @pytest.mark.parametrize(
-        "callback_data",
-        (
-            "commute:set:123",
-            "commute:delete:123",
-            "commute:clear:123",
-            "commute:cancel:123",
-            "commute_clear:confirm:123",
-            "commute_clear:cancel:123",
-        ),
-    )
-    def test_other_user_cannot_use_commute_menu(self, callback_data):
-        save_schedule(123, "월", "09:00", "18:00")
-        bot = MagicMock()
-        manager = CommuteManager(bot)
-        call = self.make_callback(callback_data, user_id=456)
-
-        manager.handle_commute_callback(call)
-
-        assert manager._build_schedule_text(123) == "월 09:00~18:00"
-        assert manager._pending_inputs == {}
-        bot.send_message.assert_not_called()
-        bot.edit_message_text.assert_not_called()
-        bot.edit_message_reply_markup.assert_not_called()
-
-    def test_other_user_cannot_consume_pending_input(self):
-        bot = MagicMock()
-        prompt_message = MagicMock()
-        prompt_message.message_id = 99
-        bot.send_message.return_value = prompt_message
-        manager = CommuteManager(bot)
-        manager.handle_commute_callback(self.make_callback("commute:set", user_id=123))
-
-        other_user_reply = make_message("월 09:00 18:00", user_id=456)
-        other_user_reply.reply_to_message = prompt_message
-        manager.handle_input_reply(other_user_reply)
-
-        assert manager._build_schedule_text(456) == strings.commute_schedule_empty_msg
-        assert (1, 99) in manager._pending_inputs
-
-    def test_pending_input_is_consumed_once_by_concurrent_replies(self):
-        bot = MagicMock()
-        manager = CommuteManager(bot)
-        manager._save_schedule_from_reply = MagicMock()
-        manager._pending_inputs[(1, 99)] = (123, "set", time.time())
-
-        replies = [
-            make_message("월 09:00 18:00", user_id=123),
-            make_message("월 09:00 18:00", user_id=123),
-        ]
-        prompt_message = MagicMock()
-        prompt_message.message_id = 99
-        for reply in replies:
-            reply.reply_to_message = prompt_message
-
-        with ThreadPoolExecutor(max_workers=2) as executor:
-            list(executor.map(manager.handle_input_reply, replies))
-
-        manager._save_schedule_from_reply.assert_called_once()
-        assert (1, 99) not in manager._pending_inputs
-
-    def test_same_message_id_is_handled_separately_per_chat(self):
-        bot = MagicMock()
-        prompt_message = MagicMock()
-        prompt_message.message_id = 99
-        bot.send_message.return_value = prompt_message
-        manager = CommuteManager(bot)
-
-        manager.handle_commute_callback(self.make_callback("commute:set", user_id=123, chat_id=1))
-        manager.handle_commute_callback(self.make_callback("commute:set", user_id=456, chat_id=2))
-
-        assert (1, 99) in manager._pending_inputs
-        assert (2, 99) in manager._pending_inputs
-
-        first_reply = make_message("월 09:00 18:00", user_id=123, chat_id=1)
-        first_reply.reply_to_message = prompt_message
-        second_reply = make_message("화 10:00 19:00", user_id=456, chat_id=2)
-        second_reply.reply_to_message = prompt_message
-
-        manager.handle_input_reply(first_reply)
-        manager.handle_input_reply(second_reply)
-
-        assert manager._build_schedule_text(123) == "월 09:00~18:00"
-        assert manager._build_schedule_text(456) == "화 10:00~19:00"
-        assert manager._pending_inputs == {}
+        bot.reply_to.assert_called_once_with(message, strings.commute_command_error_msg)
 
 
 class TestCommuteKeywords:

--- a/tests/test_features_hub.py
+++ b/tests/test_features_hub.py
@@ -107,30 +107,14 @@ class TestCalculatorHandler:
         hub.bot.reply_to.assert_not_called()
 
 
-class TestCommuteMenuHandler:
+class TestCommuteHandler:
     def test_delegates_to_commute_manager(self, hub):
-        hub.commute.show_menu = MagicMock()
+        hub.commute.handle_command = MagicMock()
         msg = make_message("/commute")
 
-        hub.commute_menu_handler(msg)
+        hub.commute_handler(msg)
 
-        hub.commute.show_menu.assert_called_once_with(msg)
-
-    def test_callback_delegates_to_commute_manager(self, hub):
-        hub.commute.handle_commute_callback = MagicMock()
-        call = MagicMock()
-
-        hub.handle_commute_callback(call)
-
-        hub.commute.handle_commute_callback.assert_called_once_with(call)
-
-    def test_reply_delegates_to_commute_manager(self, hub):
-        hub.commute.handle_input_reply = MagicMock()
-        msg = make_message("월화 09:00 18:00")
-
-        hub.handle_commute_reply(msg)
-
-        hub.commute.handle_input_reply.assert_called_once_with(msg)
+        hub.commute.handle_command.assert_called_once_with(msg)
 
 
 class TestOrdinaryMessage:

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -99,7 +99,7 @@ class TestHandlerDelegation:
         msg = make_message("/commute")
         handlers["commute"](msg)
 
-        hub.commute_menu_handler.assert_called_once_with(msg)
+        hub.commute_handler.assert_called_once_with(msg)
 
     def test_search_delegates_to_hub(self):
         hub = MagicMock()
@@ -205,28 +205,17 @@ class TestHandlerDelegation:
 
         hub.handle_spotify_callback.assert_called_once_with(query)
 
-    def test_commute_callback_delegates_to_hub(self):
+    def test_stale_commute_callback_is_ignored(self):
         hub = MagicMock()
         logger = MagicMock()
-        _, handlers = _capture_handlers(hub, logger)
+        bot, handlers = _capture_handlers(hub, logger)
 
         query = MagicMock()
-        query.data = "commute:set"
+        query.data = "commute:set:123"
         handlers["callback"](query)
 
-        hub.handle_commute_callback.assert_called_once_with(query)
-
-    def test_commute_reply_delegates_to_hub(self):
-        hub = MagicMock()
-        logger = MagicMock()
-        _, handlers = _capture_handlers(hub, logger)
-
-        msg = make_message("월화 09:00 18:00")
-        msg.reply_to_message = MagicMock()
-        msg.reply_to_message.text = strings.commute_set_input_msg
-        handlers["prompt_reply"](msg)
-
-        hub.handle_commute_reply.assert_called_once_with(msg)
+        hub.handle_commute_callback.assert_not_called()
+        bot.send_message.assert_not_called()
 
 
 class TestCallbackErrorBoundary:


### PR DESCRIPTION
  ## Summary
  - 채팅방 재진입 시 이전 ForceReply 입력창이 남는 문제 해결
  - `/commute` inline keyboard와 후속 입력 대기 방식을 하위 명령 parsing 방식으로 변경
  - 서버의 pending 상태와 Telegram client의 ForceReply 상태가 분리되어 발생하던 문제 제거

  ## Changes

  ### Commute command flow
  - `/commute`로 현재 일정과 사용법 표시
  - `/commute 등록 월화 9:00 18:00`으로 일정 등록
  - `/commute 삭제 월화`로 일부 일정 삭제
  - `/commute 전체삭제`로 전체 일정 삭제

  ### ForceReply cleanup
  - commute inline keyboard, callback, ForceReply handler 제거
  - pending input, timeout cleanup, thread lock 제거
  - 기존 ForceReply는 서버에서 pending을 정리해도 client 입력창을 닫을 수 없어, 후속 입력을 기다리지 않는 명령 방식으로 교체
  - commute callback dispatch와 기존 callback 처리 경로 제거

  ### Tests
  - 명령 parsing과 오류 응답 테스트
  - 이전 commute callback이 처리되지 않는지 확인하는 테스트
  - 기존 일정 교체 실패 시 DB rollback 테스트

  ## Test plan
  - [x] `.venv/bin/ruff check .`
  - [x] `.venv/bin/ruff format --check .`
  - [x] 전체 테스트 606개 통과
  - [x] 전체 coverage 94.81%
  - [x] Telegram 테스트 봇에서 일정 조회·등록·삭제 확인

